### PR TITLE
Fetch group geolocations from hitobito's existing JSON:API

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -79,7 +79,7 @@ services:
     App\Command\FetchDataCommand:
         arguments:
             $importDirectory: '%import_data_dir%'
-
+            $url: '%env(PBS_DATA_URL)%'
 
     # PBS Services
     App\Service\PbsApiService:

--- a/src/Command/FetchDataCommand.php
+++ b/src/Command/FetchDataCommand.php
@@ -32,13 +32,16 @@ class FetchDataCommand extends StatisticsCommand
     /**
      * FetchDataCommand constructor.
      * @param string $importDirectory
+     * @param string $url
      * @param PbsApiService $pbsApiService
      */
     public function __construct(
         string $importDirectory,
+        string $url,
         PbsApiService $pbsApiService
     ) {
         $this->targetDir = $importDirectory;
+        $this->url = $url;
         $this->pbsApiService = $pbsApiService;
         parent::__construct();
     }

--- a/src/Entity/GeoLocation.php
+++ b/src/Entity/GeoLocation.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\GeoLocationRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Table(name="midata_geo_location")
+ * @ORM\Entity(repositoryClass=GeoLocationRepository::class)
+ */
+class GeoLocation
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="float")
+     */
+    private $longitude;
+
+    /**
+     * @ORM\Column(type="float")
+     */
+    private $latitude;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=Group::class, inversedBy="geoLocations")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $abteilung;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getLongitude(): ?float
+    {
+        return $this->longitude;
+    }
+
+    public function setLongitude(float $longitude): self
+    {
+        $this->longitude = $longitude;
+
+        return $this;
+    }
+
+    public function getLatitude(): ?float
+    {
+        return $this->latitude;
+    }
+
+    public function setLatitude(float $latitude): self
+    {
+        $this->latitude = $latitude;
+
+        return $this;
+    }
+
+    public function getAbteilung(): ?Group
+    {
+        return $this->abteilung;
+    }
+
+    public function setAbteilung(?Group $abteilung): self
+    {
+        $this->abteilung = $abteilung;
+
+        return $this;
+    }
+}

--- a/src/Entity/Group.php
+++ b/src/Entity/Group.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -77,9 +78,15 @@ class Group
      */
     private $personRoles;
 
+    /**
+     * @ORM\OneToMany(targetEntity=GeoLocation::class, mappedBy="abteilung", orphanRemoval=true)
+     */
+    private $geoLocations;
+
     public function __construct()
     {
         $this->events = new ArrayCollection();
+        $this->geoLocations = new ArrayCollection();
     }
 
     /**
@@ -213,5 +220,35 @@ class Group
     public function __toString()
     {
         return (string)$this->id;
+    }
+
+    /**
+     * @return Collection|GeoLocation[]
+     */
+    public function getGeoLocations(): Collection
+    {
+        return $this->geoLocations;
+    }
+
+    public function addGeoLocation(GeoLocation $geoLocation): self
+    {
+        if (!$this->geoLocations->contains($geoLocation)) {
+            $this->geoLocations[] = $geoLocation;
+            $geoLocation->setAbteilung($this);
+        }
+
+        return $this;
+    }
+
+    public function removeGeoLocation(GeoLocation $geoLocation): self
+    {
+        if ($this->geoLocations->removeElement($geoLocation)) {
+            // set the owning side to null (unless already changed)
+            if ($geoLocation->getAbteilung() === $this) {
+                $geoLocation->setAbteilung(null);
+            }
+        }
+
+        return $this;
     }
 }

--- a/src/Migrations/Version20210805192246.php
+++ b/src/Migrations/Version20210805192246.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210805192246 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SEQUENCE midata_geo_location_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE midata_geo_location (id INT NOT NULL, abteilung_id INT NOT NULL, longitude DOUBLE PRECISION NOT NULL, latitude DOUBLE PRECISION NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_B027FE6AE862333F ON midata_geo_location (abteilung_id)');
+        $this->addSql('ALTER TABLE midata_geo_location ADD CONSTRAINT FK_B027FE6AE862333F FOREIGN KEY (abteilung_id) REFERENCES midata_group (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('DROP SEQUENCE midata_geo_location_id_seq CASCADE');
+        $this->addSql('DROP TABLE midata_geo_location');
+    }
+}

--- a/src/Repository/GeoLocationRepository.php
+++ b/src/Repository/GeoLocationRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\GeoLocation;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method GeoLocation|null find($id, $lockMode = null, $lockVersion = null)
+ * @method GeoLocation|null findOneBy(array $criteria, array $orderBy = null)
+ * @method GeoLocation[]    findAll()
+ * @method GeoLocation[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class GeoLocationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, GeoLocation::class);
+    }
+}

--- a/src/Service/PbsApiService.php
+++ b/src/Service/PbsApiService.php
@@ -42,4 +42,20 @@ class PbsApiService
         $additionalHeaders = ['X-Token' => $this->apiKey];
         return $this->guzzleWrapper->getJson($endpoint, null, $additionalHeaders);
     }
+
+    /**
+     * @param string $tableName
+     * @param int|null $page
+     * @param int|null $itemsPerPage
+     * @return Http\CurlResponse
+     */
+    public function getApiData(string $endpoint, int $page = null, int $itemsPerPage = null)
+    {
+        $endpoint = $this->url . '/' . $endpoint;
+        if ($page !== null && $itemsPerPage !== null) {
+            $endpoint .= '?page=' . $page . '&size=' . $itemsPerPage;
+        }
+        $additionalHeaders = ['X-Token' => $this->apiKey];
+        return $this->guzzleWrapper->getJson($endpoint, null, $additionalHeaders);
+    }
 }

--- a/tests/Command/FetchDataCommandTest.php
+++ b/tests/Command/FetchDataCommandTest.php
@@ -25,7 +25,7 @@ class FetchDataCommandTest extends KernelTestCase
         self::bootKernel();
         $this->targetDir = self::$kernel->getContainer()->getParameter('import_data_dir');
         $this->pbsApiServiceMock = new PbsApiServiceMock();
-        $this->command = new FetchDataCommand($this->targetDir, $this->pbsApiServiceMock);
+        $this->command = new FetchDataCommand($this->targetDir, '', $this->pbsApiServiceMock);
         $this->commandTester = new CommandTester($this->command);
     }
 


### PR DESCRIPTION
In https://github.com/digio-ch/pbs-healthcheck-core/issues/1#issuecomment-799756893 and hitobito/hitobito_pbs#201, it was proposed to add the geolocation meeting points of the Abteilungen to the dedicated health check API. To avoid feature creep in that separately maintained and highly custom API, please consider instead fetching the geolocations from the normal JSON API hitobito offers for third-party applications. The geolocations are already exposed there, since the Pfadi-Finder also needs them. This PR is therefore meant as a replacement for hitobito/hitobito_pbs#201.

I have implemented the geolocation fetching into a JSON file in one commit and the importing into a new Entity in the database in another. The reason being that I don't know what exactly you intend to do with the geolocations, and the latter commit could easily be reverted if you have different plans for the exact table layout etc.

I have tried to follow the existing code style and have run the CS checker as well as the tests and the run-import.sh script, all successfully (apart from a few code style warnings that were already there before my changes). Let me know if you'd like me to write new unit tests for the functionality I added.

For now, I only implemented importing the geolocations specifically, but in the long term, I'd like to help reduce the amount of data that is fetched via the specialized API to a minimum. Given the growing IT tool landscape of PBS and given the IT strategy document of PBS, I think it is only sensible that all tools should rather use a common MiData API instead of building and maintaining a new specialized API for every new tool.

Keep in mind: With this change, the API token that the healthcheck uses needs an additional `groups` permission in addition to the `group_health` permission, so that we are allowed to fetch the group details. I tested with the token called "Test Safari" on https://pbs.puzzle.ch.

CC @simfeld