### PR TITLE
Remove people which have been completely deleted in MiData

### DIFF
--- a/src/Command/ImportFromJsonCommand.php
+++ b/src/Command/ImportFromJsonCommand.php
@@ -776,11 +776,23 @@ class ImportFromJsonCommand extends StatisticsCommand
                 }
             });
             if (null === $matchingImportedPerson) {
+                foreach($this->em->getRepository(PersonRole::class)->findBy(['person' => $p->getId()]) as $personRole) {
+                    $this->em->remove($personRole);
+                }
+
+                foreach($this->em->getRepository(PersonEvent::class)->findBy(['person' => $p->getId()]) as $personEvent) {
+                    $this->em->remove($personEvent);
+                }
+
+                foreach($this->em->getRepository(PersonQualification::class)->findBy(['person' => $p->getId()]) as $personQualification) {
+                    $this->em->remove($personQualification);
+                }
+
                 $this->em->remove($p);
-                // TODO manually remove non-cascade-deleted entities which transitively reference midata_person
+
+                $this->em->flush();
             }
         }
-        $this->em->flush();
 
         $timeElapsed = microtime(true) - $start;
         $this->stats[] = ['people.json', $timeElapsed, $i];


### PR DESCRIPTION
Fixes #43 
Not yet tested with real data.

This will also delete people which have gotten all their healthcheck-relevant roles hard deleted in MiData, which can happen in some exceptional cases.

I still think #28 would be way cleaner, and would make this band-aid fix obsolete.