### PR TITLE
change "docker-compose" to "docker compose" for test files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
       - name: setup test env
         run: cp -f .env.test .env
       - name: Build test image
-        run: docker-compose -f docker/docker-compose.yml build --build-arg BUILD_TEST=1 healthcheck-core
+        run: docker compose -f docker/docker-compose.yml build --build-arg BUILD_TEST=1 healthcheck-core
       - name: Start compose
-        run: docker-compose -f docker/docker-compose.yml up -d
+        run: docker compose -f docker/docker-compose.yml up -d
       - name: Install dependencies
         run: docker exec --user=$(id -u) healthcheck-core-local composer install --no-interaction --no-scripts
       - name: Lint PSR12
@@ -36,6 +36,6 @@ jobs:
       - name: docker cleanup
         run: |
           cp -f .env.test .env
-          docker-compose -f docker/docker-compose.yml down
+          docker compose -f docker/docker-compose.yml down
           docker image prune -f
           docker volume prune -f


### PR DESCRIPTION
Turns out the latest Ubuntu release [Ubuntu 22.04 (20240730) Image Update](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2) removed Docker Compose v1 support. 
To fix this, we have to migrate to Docker Compose v2. 
This means changing from `docker-compose` to `docker compose`.