### PR TITLE
HC/264: refactored departments gather on federal level

### DIFF
--- a/src/Service/Apps/Quap/QuapService.php
+++ b/src/Service/Apps/Quap/QuapService.php
@@ -272,7 +272,7 @@ class QuapService
     {
         switch ($group->getGroupType()->getGroupType()) {
             case GroupType::FEDERATION:
-                $children = [GroupType::CANTON, GroupType::REGION, GroupType::DEPARTMENT];
+                $children = [GroupType::CANTON, GroupType::REGION];
                 break;
             case GroupType::CANTON:
                 $children = [GroupType::REGION, GroupType::DEPARTMENT];


### PR DESCRIPTION
Before, the "Erfolgslogik der Abteilungen" showed cantons, regions, and departments on the federal level. This might be overwhelming. Therefore, I refactored the departments' gathering to gather only cantons and regions on the federal level.