### PR TITLE
HC/278: Updated permission voter to allow special access users to access the api

### DIFF
--- a/src/Service/Security/PermissionVoter.php
+++ b/src/Service/Security/PermissionVoter.php
@@ -54,11 +54,8 @@ class PermissionVoter extends Voter
         assert($user instanceof PbsUserDTO);
         assert($subject instanceof Group);
 
-        // allow access if user in special email list and environment is either dev or stage
-        if (
-            in_array($this->environment, ['dev', 'stage']) &&
-            in_array($user->getEmail(), $this->specialAccessEmails)
-        ) {
+        // allow access if user in special email list or environment is dev
+        if ($this->environment === 'dev' || in_array($user->getEmail(), $this->specialAccessEmails)) {
             return true;
         }
 


### PR DESCRIPTION
In production, we had the issue that all API calls were blocked if you were a special user. This was due to the permission voter that wasn't adjusted. With this fix the issue is solved.