### PR TITLE
HC/307: Bumped up GitHub actions image to ubuntu-24.04

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build-dev:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Login to github docker packages registry
@@ -26,7 +26,7 @@ jobs:
 
   dispatch_deploy:
     needs: [build-dev]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Trigger Deployment
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-prod:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Login to github docker packages registry
@@ -25,7 +25,7 @@ jobs:
 
   dispatch_deploy:
     needs: [build-prod]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Trigger Deployment
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-stage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Login to github docker packages registry
@@ -25,7 +25,7 @@ jobs:
 
   dispatch_deploy:
     needs: [build-stage]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Trigger Deployment
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: setup test env
@@ -29,7 +29,7 @@ jobs:
 
   cleanup-test:
     if: always()
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [test]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The image `ubuntu-20.04` is deprecated: https://github.com/actions/runner-images/issues/11101