### PR TITLE
Gamification Improvements

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,9 +7,12 @@ parameters:
     api_prefix: "/api/v1"
     api_regex: "^/api/v1"
 
-    #pbs
+    # pbs
     import_data_dir: '%kernel.project_dir%/%env(IMPORT_TARGET_DIR)%'
     test_data_dir: '%kernel.project_dir%/tests/data'
+
+   # gamification
+    reset_endpoint_enabled_default: false
 
 services:
     # default configuration for services in *this* file
@@ -110,3 +113,9 @@ services:
     App\Service\MailService:
         arguments:
             $recipient: '%env(GAMIFICATION_RECIPIENT)%'
+
+    # Controllers
+    App\Controller\Api\GamificationController:
+        arguments:
+            # if the environment variable is not present it fallbacks to reset_endpoint_enabled_default which is false
+            $resetEndpointEnabled: '%env(bool:default:reset_endpoint_enabled_default:GAMIFICATION_RESET_ENDPOINT_ENABLED)%'

--- a/imports/gamification.json
+++ b/imports/gamification.json
@@ -5,6 +5,7 @@
       "next_key": 1,
       "type": 0,
       "required": 0,
+      "access_id": null,
       "de_title": "Newcomer*in",
       "fr_title": "Nouvel·le arrivant·e",
       "it_title": "Pricipiante"
@@ -14,6 +15,7 @@
       "next_key": 2,
       "type": 0,
       "required": 3,
+      "access_id": null,
       "de_title": "Datenentdecker*in",
       "fr_title": "Amateur·trice de données",
       "it_title": "Moogli dei dati"
@@ -23,6 +25,7 @@
       "next_key": 3,
       "type": 0,
       "required": 3,
+      "access_id": 1,
       "de_title": "Statistikforscher*in",
       "fr_title": "Statisticien·ne confirmé·e",
       "it_title": "Freak della statistica"
@@ -32,6 +35,7 @@
       "next_key": null,
       "type": 0,
       "required": 2,
+      "access_id": 1,
       "de_title": "Healthcheck Guru",
       "fr_title": "Gourou du Healthcheck",
       "it_title": "Guru di Healthcheck "
@@ -277,6 +281,14 @@
         "information": "Condividi l'accesso con almeno altre tre persone.",
         "help": "Hai condiviso l'accesso con % persone su 3."
       }
+    }
+  ],
+  "level_access": [
+    {
+      "id": 1,
+      "de_description": "nur mit Zugriff Bearbeiter*in oder Besitzer*in verfügbar",
+      "fr_description": "seulement disponible avec un accès Edition ou Propriétaire",
+      "it_description": "disponibile solo con l'accesso Modifica o Proprietario"
     }
   ]
 }

--- a/imports/gamification.json
+++ b/imports/gamification.json
@@ -61,7 +61,7 @@
     {
       "key": "CARD_LAYERS",
       "level": 1,
-      "required": true,
+      "required": false,
       "de": {
         "title": "Überblick - unterschiedliche Layer der Karte benutzt",
         "information": "Kartenlayer ein- und ausgeblendet",
@@ -81,7 +81,7 @@
     {
       "key": "DATAFILTER",
       "level": 1,
-      "required": false,
+      "required": true,
       "de": {
         "title": "Überblick - eine genaue Analyse eines Teils deiner Mitglieder",
         "information": "In der Übersicht einen Datenfilter ausgewählt",

--- a/imports/gamification.json
+++ b/imports/gamification.json
@@ -64,17 +64,17 @@
       "required": false,
       "de": {
         "title": "Überblick - unterschiedliche Layer der Karte benutzt",
-        "information": "Kartenlayer ein- und ausgeblendet. Diese Aktion ist auf kantonaler oder regionaler Ebene nicht verfügbar.",
+        "information": "Kartenlayer ein- und ausgeblendet.\nDiese Aktion ist auf kantonaler oder regionaler Ebene nicht verfügbar.",
         "help": ""
       },
       "fr": {
         "title": "Aperçu - calques de carte",
-        "information": "Tu affiches/caches un calque de la carte. Cette action n'est pas disponible au niveau cantonal ou régional.",
+        "information": "Tu affiches/caches un calque de la carte.\nCette action n'est pas disponible au niveau cantonal ou régional.",
         "help": ""
       },
       "it": {
         "title": "Panoramica - utilizza diversi livelli della cartina",
-        "information": "Visualizza/nascondi un livello della mappa. Questa azione non è disponibile a livello cantonale o regionale.",
+        "information": "Visualizza/nascondi un livello della mappa.\nQuesta azione non è disponibile a livello cantonale o regionale.",
         "help": ""
       }
     },
@@ -104,17 +104,17 @@
       "required": false,
       "de": {
         "title": "Überblick - Zeitspanne analysiert",
-        "information": "In der Übersicht eine Zeitspanne ausgewählt. Diese Aktion ist auf kantonaler oder regionaler Ebene nicht verfügbar.",
+        "information": "In der Übersicht eine Zeitspanne ausgewählt.\nDiese Aktion ist auf kantonaler oder regionaler Ebene nicht verfügbar.",
         "help": ""
       },
       "fr": {
         "title": "Aperçu - analyse temporelle",
-        "information": "Tu observes l'évolution de tes données pour une période. Cette action n'est pas disponible au niveau cantonal ou régional.",
+        "information": "Tu observes l'évolution de tes données pour une période.\nCette action n'est pas disponible au niveau cantonal ou régional.",
         "help": ""
       },
       "it": {
         "title": "Panoramica - analisi temporale",
-        "information": "Osserva come i tuoi dati cambiano nel tempo. Questa azione non è disponibile a livello cantonale o regionale.",
+        "information": "Osserva come i tuoi dati cambiano nel tempo.\nQuesta azione non è disponibile a livello cantonale o regionale.",
         "help": ""
       }
     },

--- a/imports/gamification.json
+++ b/imports/gamification.json
@@ -64,17 +64,17 @@
       "required": false,
       "de": {
         "title": "Überblick - unterschiedliche Layer der Karte benutzt",
-        "information": "Kartenlayer ein- und ausgeblendet",
+        "information": "Kartenlayer ein- und ausgeblendet. Diese Aktion ist auf kantonaler oder regionaler Ebene nicht verfügbar.",
         "help": ""
       },
       "fr": {
         "title": "Aperçu - calques de carte",
-        "information": "Tu affiches/caches un calque de la carte.",
+        "information": "Tu affiches/caches un calque de la carte. Cette action n'est pas disponible au niveau cantonal ou régional.",
         "help": ""
       },
       "it": {
         "title": "Panoramica - utilizza diversi livelli della cartina",
-        "information": "Visualizza/nascondi un livello della mappa.",
+        "information": "Visualizza/nascondi un livello della mappa. Questa azione non è disponibile a livello cantonale o regionale.",
         "help": ""
       }
     },
@@ -83,18 +83,18 @@
       "level": 1,
       "required": true,
       "de": {
-        "title": "Überblick - eine genaue Analyse eines Teils deiner Mitglieder",
-        "information": "In der Übersicht einen Datenfilter ausgewählt",
+        "title": "Eine genaue Analyse eines Teils deiner Mitglieder",
+        "information": "In der Übersicht oder der Abteilungen im Vergleich einen Datenfilter ausgewählt (je nachdem, ob du Zugriff zu einer Abteilung oder einer KV/Region hast)",
         "help": ""
       },
       "fr": {
-        "title": "Aperçu - analyse d'une partie de tes membres",
-        "information": "Tu filtres les données dans l'aperçu.",
+        "title": "Analyse d'une partie de tes membres",
+        "information": "Tu filtres les données dans l'aperçu ou la comparaison des groupes (selon si tu as accès à un groupe ou une AC/région).",
         "help": ""
       },
       "it": {
-        "title": "Panoramica - analisi di una parte dei membri",
-        "information": "Filtra i dati nella panoramica.",
+        "title": "Analisi di una parte dei membri",
+        "information": "Filtra i dati nella panoramica o confronta tra sezioni (a seconda che si abbia accesso a una sezione o a una AC/regione).",
         "help": ""
       }
     },
@@ -104,17 +104,17 @@
       "required": false,
       "de": {
         "title": "Überblick - Zeitspanne analysiert",
-        "information": "In der Übersicht eine Zeitspanne ausgewählt",
+        "information": "In der Übersicht eine Zeitspanne ausgewählt. Diese Aktion ist auf kantonaler oder regionaler Ebene nicht verfügbar.",
         "help": ""
       },
       "fr": {
         "title": "Aperçu - analyse temporelle",
-        "information": "Tu observes l'évolution de tes données pour une période.",
+        "information": "Tu observes l'évolution de tes données pour une période. Cette action n'est pas disponible au niveau cantonal ou régional.",
         "help": ""
       },
       "it": {
         "title": "Panoramica - analisi temporale",
-        "information": "Osserva come i tuoi dati cambiano nel tempo.",
+        "information": "Osserva come i tuoi dati cambiano nel tempo. Questa azione non è disponibile a livello cantonale o regionale.",
         "help": ""
       }
     },
@@ -204,17 +204,17 @@
       "required": false,
       "de": {
         "title": "Erfolgslogik - ein Aspekt überarbeitet",
-        "information": "Mindestens ein volles Kästchen später nochmals editiert",
+        "information": "Mindestens ein Kästchen später nochmals editiert",
         "help": ""
       },
       "fr": {
         "title": "Diagramme de succès - révision d'un aspect",
-        "information": "Tu modifies une réponse dans une case remplie.",
+        "information": "Tu modifies une réponse dans une case.",
         "help": ""
       },
       "it": {
         "title": "Logica del successo - revisione di un aspetto",
-        "information": "Modifica una risposta in un riquadro compilato.",
+        "information": "Modifica una risposta in un riquadro.",
         "help": ""
       }
     },

--- a/run-import.sh
+++ b/run-import.sh
@@ -15,6 +15,7 @@ docker exec healthcheck-importer-dev pbs-healthcheck-importer -v import
 # Run import commands from symfony project
 docker exec --user=www-data healthcheck-core-dev /usr/local/bin/php /srv/bin/console app:map-peoples-addresses
 docker exec --user=www-data healthcheck-core-dev /usr/local/bin/php /srv/bin/console app:quap:import-questionnaire
+docker exec --user=www-data healthcheck-core-dev /usr/local/bin/php /srv/bin/console app:import-gamification
 
 # run the aggregator command from the go importer
 docker exec healthcheck-importer-dev pbs-healthcheck-importer -v aggregate

--- a/src/Command/ImportGamificationCommand.php
+++ b/src/Command/ImportGamificationCommand.php
@@ -47,11 +47,11 @@ class ImportGamificationCommand extends StatisticsCommand
         $start = microtime(true);
         $json = json_decode(file_get_contents($this->pathToJson), true);
 
-        $this->em->getConnection()->executeQuery('DELETE FROM gamification_person_profile');
-        $this->em->getConnection()->executeQuery('DELETE FROM goal');
-        $this->em->getConnection()->executeQuery('DELETE FROM level_up_log');
-        $this->em->getConnection()->executeQuery('DELETE FROM level');
-        $this->em->getConnection()->executeQuery('DELETE FROM level_access');
+        $this->em->getConnection()->executeQuery('DELETE FROM hc_gamification_person_profile');
+        $this->em->getConnection()->executeQuery('DELETE FROM hc_gamification_goal');
+        $this->em->getConnection()->executeQuery('DELETE FROM hc_gamification_level_up_log');
+        $this->em->getConnection()->executeQuery('DELETE FROM hc_gamification_level');
+        $this->em->getConnection()->executeQuery('DELETE FROM hc_gamification_level_access');
 
         if (is_null($json['level_access'])) {
             $output->writeln('No level access requirements found.');

--- a/src/Controller/Api/Apps/QuapController.php
+++ b/src/Controller/Api/Apps/QuapController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Api\Apps;
 use App\DTO\Mapper\QuestionnaireMapper;
 use App\DTO\Model\FilterRequestData\DateRequestData;
 use App\DTO\Model\FilterRequestData\OptionalDateRequestData;
+use App\Entity\Gamification\Goal;
 use App\Entity\Midata\Group;
 use App\Entity\Midata\GroupType;
 use App\Exception\ApiException;
@@ -178,7 +179,7 @@ class QuapController extends AbstractController
         }
 
         $this->quapService->updateAllowAccess($group, $payload['allow_access']);
-        $personGamificationService->genericGoalProgress($this->getUser(), 'shareEL');
+        $personGamificationService->genericGoalProgress($this->getUser(), Goal::TYPE_SHARE_EL);
 
         return $this->json([], JsonResponse::HTTP_NO_CONTENT);
     }

--- a/src/Controller/Api/GamificationController.php
+++ b/src/Controller/Api/GamificationController.php
@@ -19,8 +19,23 @@ use Symfony\Component\HttpFoundation\Response;
 class GamificationController extends AbstractController
 {
     /**
+     * Specifies whether the reset endpoint should be enabled.
+     *
+     * This value is injected by the environment variable GAMIFICATION_RESET_ENDPOINT_ENABLED.
+     * If the variable is not present it fallbacks to false.
+     * @var bool $resetEndpointEnabled
+     */
+    private bool $resetEndpointEnabled;
+
+    public function __construct(bool $resetEndpointEnabled)
+    {
+        $this->resetEndpointEnabled = $resetEndpointEnabled;
+    }
+
+    /**
      * @param Request $request
      * @param LoginService $loginService
+     * @param GroupRepository $groupRepository
      * @return Response
      */
     public function postGroupChange(
@@ -75,6 +90,13 @@ class GamificationController extends AbstractController
 
     public function resetGamification(Request $request, PersonGamificationService $personGamificationService): Response
     {
+        if (!$this->resetEndpointEnabled) {
+            return new JsonResponse([
+                "code" => 404,
+                "error" => "reset endpoint is disabled"
+            ], 404);
+        }
+
         $personGamificationService->reset($this->getUser());
         return new Response('');
     }

--- a/src/Controller/Api/GamificationController.php
+++ b/src/Controller/Api/GamificationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Api;
 
+use App\Entity\Gamification\Goal;
 use App\Entity\Midata\Group;
 use App\Entity\Security\Permission;
 use App\Exception\ApiException;
@@ -44,7 +45,7 @@ class GamificationController extends AbstractController
         Request $request,
         PersonGamificationService $personGamificationService
     ) {
-        $personGamificationService->genericGoalProgress($this->getUser(), 'card');
+        $personGamificationService->genericGoalProgress($this->getUser(), Goal::TYPE_CARD_LAYERS);
         return new Response('', 200);
     }
 
@@ -52,7 +53,7 @@ class GamificationController extends AbstractController
         Request $request,
         PersonGamificationService $personGamificationService
     ) {
-        $personGamificationService->genericGoalProgress($this->getUser(), 'data');
+        $personGamificationService->genericGoalProgress($this->getUser(), Goal::TYPE_DATA_FILTER);
         return new Response('', 200);
     }
 
@@ -60,7 +61,7 @@ class GamificationController extends AbstractController
         Request $request,
         PersonGamificationService $personGamificationService
     ) {
-        $personGamificationService->genericGoalProgress($this->getUser(), 'time');
+        $personGamificationService->genericGoalProgress($this->getUser(), Goal::TYPE_TIME_FILTER);
         return new Response('', 200);
     }
 

--- a/src/Controller/Api/InviteController.php
+++ b/src/Controller/Api/InviteController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Api;
 
 use App\DTO\Model\InviteDTO;
+use App\Entity\Gamification\Goal;
 use App\Entity\Midata\Group;
 use App\Entity\Security\Permission;
 use App\Exception\ApiException;
@@ -90,7 +91,7 @@ class InviteController extends AbstractController
         }
 
         $createdInviteDTO = $this->inviteService->createInvite($group, $inviteDTO);
-        $personGamificationService->genericGoalProgress($this->getUser(), 'invite');
+        $personGamificationService->genericGoalProgress($this->getUser(), Goal::TYPE_SHARE_ONE);
 
         return $this->json($createdInviteDTO, JsonResponse::HTTP_CREATED);
     }

--- a/src/DTO/Mapper/GamificationLevelMapper.php
+++ b/src/DTO/Mapper/GamificationLevelMapper.php
@@ -2,10 +2,9 @@
 
 namespace App\DTO\Mapper;
 
-use App\DTO\Model\Gamification\GoalDTO;
 use App\DTO\Model\Gamification\LevelDTO;
-use App\Entity\Gamification\Goal;
 use App\Entity\Gamification\Level;
+use App\Entity\Gamification\LevelAccess;
 
 class GamificationLevelMapper
 {
@@ -16,6 +15,9 @@ class GamificationLevelMapper
         $dto->setKey($level->getKey());
         $dto->setRequired($level->getRequired());
 
+        $access = self::mapAccess($locale, $level->getAccess());
+        $dto->setAccess($access);
+
         if ($locale === 'de') {
             $dto->setTitle($level->getDeTitle());
         } elseif ($locale === 'it') {
@@ -24,5 +26,23 @@ class GamificationLevelMapper
             $dto->setTitle($level->getFrTitle());
         }
         return $dto;
+    }
+
+    private static function mapAccess(string $locale, ?LevelAccess $access): ?string
+    {
+        if (is_null($access)) {
+            return null;
+        }
+
+        switch ($locale) {
+            case 'de':
+                return $access->getDeDescription();
+            case 'it':
+                return $access->getItDescription();
+            case 'fr':
+                return $access->getFrDescription();
+        }
+
+        return "";
     }
 }

--- a/src/DTO/Model/Gamification/LevelDTO.php
+++ b/src/DTO/Model/Gamification/LevelDTO.php
@@ -10,6 +10,7 @@ class LevelDTO
     private array $goals;
     private bool $active;
     private int $required;
+    private ?string $access;
 
     /**
      * @return int
@@ -89,5 +90,22 @@ class LevelDTO
     public function setGoals(array $goals): void
     {
         $this->goals = $goals;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAccess(): ?string
+    {
+        return $this->access;
+    }
+
+    /**
+     * @param string|null $access
+     * @return void
+     */
+    public function setAccess(?string $access): void
+    {
+        $this->access = $access;
     }
 }

--- a/src/Entity/Aggregated/AggregatedQuap.php
+++ b/src/Entity/Aggregated/AggregatedQuap.php
@@ -14,6 +14,13 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class AggregatedQuap extends AggregatedEntity
 {
+    public const NO_ANSWER = 0;
+    public const ANSWER_IRRELEVANT = 5;
+    public const ANSWER_NOT_IMPLEMENTED = 4;
+    public const ANSWER_PARTIALLY_FULFILLED = 3;
+    public const ANSWER_MOSTLY_FULFILLED = 2;
+    public const ANSWER_FULFILLED = 1;
+
     /**
      * @ORM\ManyToOne(targetEntity=Questionnaire::class, inversedBy = "widgetQuap")
      * @ORM\JoinColumn(nullable=false)

--- a/src/Entity/Gamification/GamificationPersonProfile.php
+++ b/src/Entity/Gamification/GamificationPersonProfile.php
@@ -7,6 +7,7 @@ use App\Repository\Gamification\GamificationPersonProfileRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
+ * @ORM\Table(name="hc_gamification_person_profile")
  * @ORM\Entity(repositoryClass=GamificationPersonProfileRepository::class)
  */
 class GamificationPersonProfile

--- a/src/Entity/Gamification/GamificationQuapEvent.php
+++ b/src/Entity/Gamification/GamificationQuapEvent.php
@@ -10,6 +10,7 @@ use App\Repository\Gamification\GamificationQuapEventRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
+ * @ORM\Table(name="hc_gamification_quap_event")
  * @ORM\Entity(repositoryClass=GamificationQuapEventRepository::class)
  */
 class GamificationQuapEvent

--- a/src/Entity/Gamification/Goal.php
+++ b/src/Entity/Gamification/Goal.php
@@ -10,6 +10,19 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Goal
 {
+    public const TYPE_FIRST_LOGIN = "FIRST_LOGIN";
+    public const TYPE_CARD_LAYERS = "CARD_LAYERS";
+    public const TYPE_DATA_FILTER = "DATAFILTER";
+    public const TYPE_TIME_FILTER = "TIMEFILTER";
+    public const TYPE_SHARE_EL = "SHARE_WITH_PARENTS";
+    public const TYPE_EL_FILL_OUT = "EL_FILL_OUT";
+    public const TYPE_SHARE_ONE = "SHARE_1";
+    public const TYPE_EL_IRRELEVANT = "EL_IRRELEVANT";
+    public const TYPE_EL_REVISION = "EL_CHANGE";
+    public const TYPE_EL_IMPROVEMENT = "EL_IMPROVE";
+    public const TYPE_LOGIN_FOUR_A_YEAR = "LOGIN_FOUR_A_YEAR";
+    public const TYPE_SHARE_THREE = "SHARE_THREE";
+
     /**
      * @ORM\Id
      * @ORM\GeneratedValue

--- a/src/Entity/Gamification/Goal.php
+++ b/src/Entity/Gamification/Goal.php
@@ -6,6 +6,7 @@ use App\Repository\Gamification\GoalRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
+ * @ORM\Table(name="hc_gamification_goal")
  * @ORM\Entity(repositoryClass=GoalRepository::class)
  */
 class Goal

--- a/src/Entity/Gamification/Level.php
+++ b/src/Entity/Gamification/Level.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
+ * @ORM\Table(name="hc_gamification_level")
  * @ORM\Entity(repositoryClass=LevelRepository::class)
  */
 class Level

--- a/src/Entity/Gamification/Level.php
+++ b/src/Entity/Gamification/Level.php
@@ -22,6 +22,13 @@ class Level
     private $id;
 
     /**
+     * @ORM\ManyToOne(targetEntity=LevelAccess::class)
+     * @ORM\JoinColumn(nullable=true)
+     * @var LevelAccess | null $access
+     */
+    private $access;
+
+    /**
      * @ORM\Column(type="integer")
      */
     private $type;
@@ -103,6 +110,16 @@ class Level
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getAccess(): ?LevelAccess
+    {
+        return $this->access;
+    }
+
+    public function setAccess(?LevelAccess $access): void
+    {
+        $this->access = $access;
     }
 
     public function getType(): ?int

--- a/src/Entity/Gamification/LevelAccess.php
+++ b/src/Entity/Gamification/LevelAccess.php
@@ -6,6 +6,7 @@ use App\Repository\Gamification\LevelAccessRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
+ * @ORM\Table(name="hc_gamification_level_access")
  * @ORM\Entity(repositoryClass=LevelAccessRepository::class)
  */
 class LevelAccess

--- a/src/Entity/Gamification/LevelAccess.php
+++ b/src/Entity/Gamification/LevelAccess.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Entity\Gamification;
+
+use App\Repository\Gamification\LevelAccessRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass=LevelAccessRepository::class)
+ */
+class LevelAccess
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private int $id;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private string $de_description;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private string $fr_description;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private string $it_description;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getDeDescription(): string
+    {
+        return $this->de_description;
+    }
+
+    public function setDeDescription(string $de_description): void
+    {
+        $this->de_description = $de_description;
+    }
+
+    public function getFrDescription(): string
+    {
+        return $this->fr_description;
+    }
+
+    public function setFrDescription(string $fr_description): void
+    {
+        $this->fr_description = $fr_description;
+    }
+
+    public function getItDescription(): string
+    {
+        return $this->it_description;
+    }
+
+    public function setItDescription(string $it_description): void
+    {
+        $this->it_description = $it_description;
+    }
+
+
+}

--- a/src/Entity/Gamification/LevelUpLog.php
+++ b/src/Entity/Gamification/LevelUpLog.php
@@ -7,6 +7,7 @@ use App\Repository\Gamification\LevelUpLogRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
+ * @ORM\Table(name="hc_gamification_level_up_log")
  * @ORM\Entity(repositoryClass=LevelUpLogRepository::class)
  */
 class LevelUpLog

--- a/src/Entity/Gamification/Login.php
+++ b/src/Entity/Gamification/Login.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
+ * @ORM\Table(name="hc_gamification_login")
  * @ORM\Entity(repositoryClass=LoginRepository::class)
  */
 class Login

--- a/src/Migrations/Version20250912073257.php
+++ b/src/Migrations/Version20250912073257.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250912073257 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SEQUENCE level_access_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE level_access (id INT NOT NULL, de_description VARCHAR(255) NOT NULL, fr_description VARCHAR(255) NOT NULL, it_description VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('ALTER TABLE level ADD COLUMN access_id INT NULL DEFAULT NULL, ADD CONSTRAINT fK_level_access FOREIGN KEY(access_id) REFERENCES level_access(id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE level DROP CONSTRAINT fK_level_access, DROP COLUMN access_id');
+        $this->addSql('DROP TABLE level_access');
+        $this->addSql('DROP SEQUENCE level_access_id_seq');
+    }
+}

--- a/src/Migrations/Version20250912100226.php
+++ b/src/Migrations/Version20250912100226.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250912100226 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql("ALTER SEQUENCE gamification_person_profile_id_seq RENAME TO hc_gamification_person_profile_id_seq");
+        $this->addSql("ALTER SEQUENCE gamification_quap_event_id_seq RENAME TO hc_gamification_quap_event_id_seq");
+        $this->addSql("ALTER SEQUENCE goal_id_seq RENAME TO hc_gamification_goal_id_seq");
+        $this->addSql("ALTER SEQUENCE level_access_id_seq RENAME TO hc_gamification_level_access_id_seq");
+        $this->addSql("ALTER SEQUENCE level_id_seq RENAME TO hc_gamification_level_id_seq");
+        $this->addSql("ALTER SEQUENCE level_up_log_id_seq RENAME TO hc_gamification_level_up_log_id_seq");
+        $this->addSql("ALTER SEQUENCE login_id_seq RENAME TO hc_gamification_login_id_seq");
+
+        $this->addSql("ALTER TABLE gamification_person_profile RENAME TO hc_gamification_person_profile");
+        $this->addSql("ALTER TABLE gamification_quap_event RENAME TO hc_gamification_quap_event");
+        $this->addSql("ALTER TABLE goal RENAME TO hc_gamification_goal");
+        $this->addSql("ALTER TABLE level RENAME TO hc_gamification_level");
+        $this->addSql("ALTER TABLE level_access RENAME TO hc_gamification_level_access");
+        $this->addSql("ALTER TABLE level_up_log RENAME TO hc_gamification_level_up_log");
+        $this->addSql("ALTER TABLE login RENAME TO hc_gamification_login");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql("ALTER SEQUENCE hc_gamification_person_profile_id_seq RENAME TO gamification_person_profile_id_seq");
+        $this->addSql("ALTER SEQUENCE hc_gamification_quap_event_id_seq RENAME TO gamification_quap_event_id_seq");
+        $this->addSql("ALTER SEQUENCE hc_gamification_goal_id_seq RENAME TO goal_id_seq");
+        $this->addSql("ALTER SEQUENCE hc_gamification_level_access_id_seq RENAME TO level_access_id_seq");
+        $this->addSql("ALTER SEQUENCE hc_gamification_level_id_seq RENAME TO level_id_seq");
+        $this->addSql("ALTER SEQUENCE hc_gamification_level_up_log_id_seq RENAME TO level_up_log_id_seq");
+        $this->addSql("ALTER SEQUENCE hc_gamification_login_id_seq RENAME TO login_id_seq");
+
+        $this->addSql("ALTER TABLE hc_gamification_person_profile RENAME TO gamification_person_profile");
+        $this->addSql("ALTER TABLE hc_gamification_quap_event RENAME TO gamification_quap_event");
+        $this->addSql("ALTER TABLE hc_gamification_goal RENAME TO goal");
+        $this->addSql("ALTER TABLE hc_gamification_level RENAME TO level");
+        $this->addSql("ALTER TABLE hc_gamification_level_access RENAME TO level_access");
+        $this->addSql("ALTER TABLE hc_gamification_level_up_log RENAME TO level_up_log");
+        $this->addSql("ALTER TABLE hc_gamification_login RENAME TO login");
+    }
+}

--- a/src/Repository/Gamification/LevelAccessRepository.php
+++ b/src/Repository/Gamification/LevelAccessRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Repository\Gamification;
+
+use App\Entity\Gamification\LevelAccess;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<LevelAccess>
+ *
+ * @method LevelAccess|null find($id, $lockMode = null, $lockVersion = null)
+ * @method LevelAccess|null findOneBy(array $criteria, array $orderBy = null)
+ * @method LevelAccess[]    findAll()
+ * @method LevelAccess[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class LevelAccessRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LevelAccess::class);
+    }
+
+    /**
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function add(LevelAccess $entity, bool $flush = true): void
+    {
+        $this->_em->persist($entity);
+        if ($flush) {
+            $this->_em->flush();
+        }
+    }
+}

--- a/src/Repository/Quap/QuestionnaireRepository.php
+++ b/src/Repository/Quap/QuestionnaireRepository.php
@@ -48,19 +48,19 @@ class QuestionnaireRepository extends ServiceEntityRepository
     {
         $conn = $this->_em->getConnection();
         $query = $conn->executeQuery(
-            "SELECT \"type\", COUNT(*) FROM (
+            'SELECT "type", COUNT(*) FROM (
                     SELECT 
-                        hc_quap_questionnaire.\"type\",
+                        hc_quap_questionnaire."type",
                         BOOL_AND(
                             hc_quap_question.evaluation_function IS NOT NULL
                         ) as automatic
                     FROM hc_quap_questionnaire
                     JOIN hc_quap_aspect ON hc_quap_aspect.questionnaire_id = hc_quap_questionnaire.id
                     JOIN hc_quap_question ON hc_quap_question.aspect_id = hc_quap_aspect.id
-                    GROUP BY hc_quap_questionnaire.id, hc_quap_questionnaire.\"type\", hc_quap_aspect.id
+                    GROUP BY hc_quap_questionnaire.id, hc_quap_questionnaire."type", hc_quap_aspect.id
                 ) as p
                 WHERE automatic = FALSE
-                GROUP BY \"type\";",
+                GROUP BY "type";',
         );
         return $query->fetchAllKeyValue();
     }

--- a/src/Service/Gamification/PersonGamificationService.php
+++ b/src/Service/Gamification/PersonGamificationService.php
@@ -159,7 +159,7 @@ class PersonGamificationService
         $nextLevel = $nextLevel[0];
         $levelUp = false;
         if ($currentLevel->getKey() === 0) {
-            if ($person->getHasUsedCardLayer() && ($person->getHasUsedDatafilter() || $person->getHasUsedTimefilter() || $person->getHasSharedEl())) {
+            if ($person->getHasUsedDatafilter() && ($person->getHasUsedCardLayer() || $person->getHasUsedTimefilter() || $person->getHasSharedEl())) {
                 $levelUp = true;
             }
         }

--- a/src/Service/Gamification/QuapGamificationService.php
+++ b/src/Service/Gamification/QuapGamificationService.php
@@ -4,6 +4,7 @@ namespace App\Service\Gamification;
 
 use App\DTO\Model\PbsUserDTO;
 use App\Entity\Aggregated\AggregatedQuap;
+use App\Entity\Gamification\Goal;
 use App\Entity\Midata\Group;
 use App\Repository\Aggregated\AggregatedQuapRepository;
 
@@ -66,13 +67,13 @@ class QuapGamificationService
         }
 
         if ($revision) {
-            $this->personGamificationService->genericGoalProgress($pbsUserDTO, 'revised');
+            $this->personGamificationService->genericGoalProgress($pbsUserDTO, Goal::TYPE_EL_REVISION);
         }
         if ($irrelevant) {
-            $this->personGamificationService->genericGoalProgress($pbsUserDTO, 'irrelevant');
+            $this->personGamificationService->genericGoalProgress($pbsUserDTO, Goal::TYPE_EL_IRRELEVANT);
         }
         if ($improvement) {
-            $this->personGamificationService->genericGoalProgress($pbsUserDTO, 'improvement');
+            $this->personGamificationService->genericGoalProgress($pbsUserDTO, Goal::TYPE_EL_IMPROVEMENT);
         }
 
         $this->personGamificationService->logEvent($changedQuestionnaires, $aggregatedQuap, $pbsUserDTO);


### PR DESCRIPTION
- fixed gamification quap processing logic
- fixed calculation of task _quap filled out_
- new gamification translations
- replaced goal type strings with variables: 'TYPE_FILL_OUT' -> Goal::TYPE_FILL_OUT
- add level access to gamification level
- > Level Access: Describes the needed permissions to be able to solve the tasks of a level
- fixed gamification tables naming
- added logic to disable gamification reset endpoint over an environment variable for production
