### PR TITLE
HC-343: Share Overview with Parent Regions / Cantons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,7 @@ test:
 	docker exec healthcheck-core-local php vendor/bin/phpcs --standard=PSR12 --report=full --ignore=src/Migrations/ --runtime-set ignore_warnings_on_exit 1 src/
 	docker exec healthcheck-core-local php bin/phpunit || true
 	docker compose -p healthcheck-test -f docker/docker-compose.yml down
+
+.PHONY: lint
+lint:
+	docker exec healthcheck-core-local php vendor/bin/phpcs --standard=PSR12 --report=full --ignore=src/Migrations/ --runtime-set ignore_warnings_on_exit 1 src/

--- a/config/routes/app_routes.yml
+++ b/config/routes/app_routes.yml
@@ -5,6 +5,12 @@ widgets:
   prefix: /widgets
   name_prefix: widgets_
 
+# Overview routes
+overview:
+  resource: "apps/overview.yml"
+  prefix: /overview
+  name_prefix: overview_
+
 # QUAP routes
 quap:
   resource: "apps/quap.yml"

--- a/config/routes/apps/overview.yml
+++ b/config/routes/apps/overview.yml
@@ -3,3 +3,8 @@ sharing:
   path: /share
   methods: GET
   controller: App\Controller\Api\Apps\OverviewController::getOverviewSharing
+
+share:
+  path: /share
+  methods: POST
+  controller: App\Controller\Api\Apps\OverviewController::shareOverview

--- a/config/routes/apps/overview.yml
+++ b/config/routes/apps/overview.yml
@@ -27,6 +27,11 @@ departments_filter:
   methods: GET
   controller: App\Controller\Api\Apps\Widgets\FilterController:getFilterDataOfDepartment
 
+members_gender:
+  path: /departments/{departmentId}/members-gender
+  methods: GET
+  controller: App\Controller\Api\Apps\Widgets\MembersGenderController:getDemographicGroupDataOfDepartment
+
 departments_members_group:
   path: /departments/{departmentId}/members-group
   methods: GET

--- a/config/routes/apps/overview.yml
+++ b/config/routes/apps/overview.yml
@@ -1,19 +1,27 @@
 
+# Department Overview Endpoints
 sharing:
   path: /share
   methods: GET
-  controller: App\Controller\Api\Apps\OverviewController::getOverviewSharing
+  controller: App\Controller\Api\Apps\OverviewController:getOverviewSharing
 
 share:
   path: /share
   methods: POST
-  controller: App\Controller\Api\Apps\OverviewController::shareOverview
+  controller: App\Controller\Api\Apps\OverviewController:shareOverview
 
+# Region/Canton Overview Endpoints
 departments_preview:
   path: /departments/preview
   methods: GET
-  controller: App\Controller\Api\Apps\OverviewController::getOverviewOfDepartmentsPreview
+  controller: App\Controller\Api\Apps\OverviewController:getOverviewOfDepartmentsPreview
 
+departments:
+  path: /departments
+  methods: GET
+  controller: App\Controller\Api\Apps\OverviewController:getOverviewOfDepartments
+
+# Widget Endpoints for Regions/Cantons
 departments_filter:
   path: /departments/{departmentId}/filter
   methods: GET

--- a/config/routes/apps/overview.yml
+++ b/config/routes/apps/overview.yml
@@ -9,7 +9,47 @@ share:
   methods: POST
   controller: App\Controller\Api\Apps\OverviewController::shareOverview
 
-departments-preview:
+departments_preview:
   path: /departments/preview
   methods: GET
   controller: App\Controller\Api\Apps\OverviewController::getOverviewOfDepartmentsPreview
+
+departments_filter:
+  path: /departments/{departmentId}/filter
+  methods: GET
+  controller: App\Controller\Api\Apps\Widgets\FilterController:getFilterDataOfDepartment
+
+departments_members_group:
+  path: /departments/{departmentId}/members-group
+  methods: GET
+  controller: App\Controller\Api\Apps\Widgets\MembersGroupController:getGroupMembersDataOfDepartment
+
+departments_demographic_camp:
+  path: /departments/{departmentId}/camps
+  methods: GET
+  controller: App\Controller\Api\Apps\Widgets\CampController:getDemographicCampDataOfDepartment
+
+departments_leader_overview:
+  path: /departments/{departmentId}/leader-overview
+  methods: GET
+  controller: App\Controller\Api\Apps\Widgets\LeaderOverviewController:getLeaderOverviewDataOfDepartment
+
+departments_members_birthyear:
+  path: /departments/{departmentId}/age-group-demographic
+  methods: GET
+  controller: App\Controller\Api\Apps\Widgets\MembersBirthyearController:getMembersBirthyearDataOfDepartment
+
+departments_members_entered_left:
+  path: /departments/{departmentId}/entered-left
+  methods: GET
+  controller: App\Controller\Api\Apps\Widgets\MembersEnteredLeftController:getEnteredLeftMembersDataOfDepartment
+
+departments_geo_location:
+  path: /departments/{departmentId}/geo-location
+  methods: GET
+  controller: App\Controller\Api\Apps\Widgets\GeoLocationController::getGeoLocationsOfDepartment
+
+departments_role_overview:
+  path: /departments/{departmentId}/role-overview
+  methods: GET
+  controller: App\Controller\Api\Apps\Widgets\RoleOverviewController:getRoleOverviewOfDepartment

--- a/config/routes/apps/overview.yml
+++ b/config/routes/apps/overview.yml
@@ -1,0 +1,5 @@
+
+sharing:
+  path: /share
+  methods: GET
+  controller: App\Controller\Api\Apps\OverviewController::getOverviewSharing

--- a/config/routes/apps/overview.yml
+++ b/config/routes/apps/overview.yml
@@ -8,3 +8,8 @@ share:
   path: /share
   methods: POST
   controller: App\Controller\Api\Apps\OverviewController::shareOverview
+
+departments-preview:
+  path: /departments/preview
+  methods: GET
+  controller: App\Controller\Api\Apps\OverviewController::getOverviewOfDepartmentsPreview

--- a/src/Controller/Api/Apps/OverviewController.php
+++ b/src/Controller/Api/Apps/OverviewController.php
@@ -4,11 +4,13 @@ namespace App\Controller\Api\Apps;
 
 use App\DTO\Model\Apps\Overview\OverviewSharingDTO;
 use App\Entity\Midata\Group;
+use App\Exception\ApiException;
 use App\Service\Apps\Overview\OverviewSharedService;
 use App\Service\Security\PermissionVoter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 class OverviewController extends AbstractController
 {
@@ -33,5 +35,32 @@ class OverviewController extends AbstractController
         $isShared = $this->overviewSharedService->isShared($group->getId());
 
         return $this->json(new OverviewSharingDTO($isShared));
+    }
+
+    /**
+     * @param Request $request
+     * @param Group $group
+     * @return JsonResponse
+     *
+     * @ParamConverter("group", options={"mapping": {"groupId": "id"}})
+     */
+    public function shareOverview(Request $request, Group $group)
+    {
+        $this->denyAccessUnlessGranted(PermissionVoter::OWNER, $group);
+
+        $json = json_decode($request->getContent(), true);
+        if (is_null($json)) {
+            throw new ApiException(400, "Invalid JSON");
+        }
+
+        $share = $json['share'];
+
+        if (!is_bool($share)) {
+            throw new ApiException(400, "Invalid JSON");
+        }
+
+        $this->overviewSharedService->shareOverview($group->getId(), $share);
+
+        return $this->json(new OverviewSharingDTO($share));
     }
 }

--- a/src/Controller/Api/Apps/OverviewController.php
+++ b/src/Controller/Api/Apps/OverviewController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Controller\Api\Apps;
+
+use App\DTO\Model\Apps\Overview\OverviewSharingDTO;
+use App\Entity\Midata\Group;
+use App\Service\Apps\Overview\OverviewSharedService;
+use App\Service\Security\PermissionVoter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class OverviewController extends AbstractController
+{
+    private OverviewSharedService $overviewSharedService;
+
+    public function __construct(
+        OverviewSharedService $overviewSharedService
+    ) {
+        $this->overviewSharedService = $overviewSharedService;
+    }
+
+    /**
+     * @param Group $group
+     * @return JsonResponse
+     *
+     * @ParamConverter("group", options={"mapping": {"groupId": "id"}})
+     */
+    public function getOverviewSharing(Group $group)
+    {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $group);
+
+        $isShared = $this->overviewSharedService->isShared($group->getId());
+
+        return $this->json(new OverviewSharingDTO($isShared));
+    }
+}

--- a/src/Controller/Api/Apps/OverviewController.php
+++ b/src/Controller/Api/Apps/OverviewController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api\Apps;
 
 use App\DTO\Model\Apps\Overview\OverviewSharingDTO;
 use App\Entity\Midata\Group;
+use App\Entity\Midata\GroupType;
 use App\Exception\ApiException;
 use App\Service\Apps\Overview\OverviewSharedService;
 use App\Service\Security\PermissionVoter;
@@ -28,9 +29,13 @@ class OverviewController extends AbstractController
      *
      * @ParamConverter("group", options={"mapping": {"groupId": "id"}})
      */
-    public function getOverviewSharing(Group $group)
+    public function getOverviewSharing(Group $group): JsonResponse
     {
         $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $group);
+
+        if (!$this->isDepartment($group)) {
+            throw new ApiException(400, "Only for departments");
+        }
 
         $isShared = $this->overviewSharedService->isShared($group->getId());
 
@@ -44,9 +49,13 @@ class OverviewController extends AbstractController
      *
      * @ParamConverter("group", options={"mapping": {"groupId": "id"}})
      */
-    public function shareOverview(Request $request, Group $group)
+    public function shareOverview(Request $request, Group $group): JsonResponse
     {
         $this->denyAccessUnlessGranted(PermissionVoter::OWNER, $group);
+
+        if (!$this->isDepartment($group)) {
+            throw new ApiException(400, "Only for departments");
+        }
 
         $json = json_decode($request->getContent(), true);
         if (is_null($json)) {
@@ -62,5 +71,35 @@ class OverviewController extends AbstractController
         $this->overviewSharedService->shareOverview($group->getId(), $share);
 
         return $this->json(new OverviewSharingDTO($share));
+    }
+
+    /**
+     * @param Group $group
+     * @return JsonResponse
+     *
+     * @ParamConverter("group", options={"mapping": {"groupId": "id"}})
+     */
+    public function getOverviewOfDepartmentsPreview(Group $group): JsonResponse
+    {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $group);
+
+        if (!$this->isRegionOrCanton($group)) {
+            throw new ApiException(400, "Only for regions and cantons");
+        }
+
+        $preview = $this->overviewSharedService->getDepartmentsPreview($group);
+
+        return $this->json($preview);
+    }
+
+    private function isDepartment(Group $group): bool
+    {
+        return $group->getGroupType()->getGroupType() === GroupType::DEPARTMENT;
+    }
+
+    private function isRegionOrCanton(Group $group): bool
+    {
+        $groupType = $group->getGroupType()->getGroupType();
+        return $groupType === GroupType::CANTON || $groupType === GroupType::REGION;
     }
 }

--- a/src/Controller/Api/Apps/OverviewController.php
+++ b/src/Controller/Api/Apps/OverviewController.php
@@ -8,6 +8,7 @@ use App\Entity\Midata\GroupType;
 use App\Exception\ApiException;
 use App\Service\Apps\Overview\OverviewSharedService;
 use App\Service\Security\PermissionVoter;
+use Doctrine\DBAL\Exception;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -78,6 +79,7 @@ class OverviewController extends AbstractController
      * @return JsonResponse
      *
      * @ParamConverter("group", options={"mapping": {"groupId": "id"}})
+     * @throws Exception
      */
     public function getOverviewOfDepartmentsPreview(Group $group): JsonResponse
     {
@@ -90,6 +92,26 @@ class OverviewController extends AbstractController
         $preview = $this->overviewSharedService->getDepartmentsPreview($group);
 
         return $this->json($preview);
+    }
+
+    /**
+     * @param Group $group
+     * @return JsonResponse
+     *
+     * @ParamConverter("group", options={"mapping": {"groupId": "id"}})
+     * @throws Exception
+     */
+    public function getOverviewOfDepartments(Group $group): JsonResponse
+    {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $group);
+
+        if (!$this->isRegionOrCanton($group)) {
+            throw new ApiException(400, "Only for regions and cantons");
+        }
+
+        $data = $this->overviewSharedService->getDepartments($group);
+
+        return $this->json($data);
     }
 
     private function isDepartment(Group $group): bool

--- a/src/Controller/Api/Apps/Widgets/CampController.php
+++ b/src/Controller/Api/Apps/Widgets/CampController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Api\Apps\Widgets;
 
 use App\DTO\Model\FilterRequestData\DateRangeRequestData;
+use App\DTO\Model\FilterRequestData\WidgetOfDepartmentRequestData;
 use App\DTO\Model\FilterRequestData\WidgetRequestData;
 use App\Service\DataProvider\DemographicCampDataProvider;
 use App\Service\Security\PermissionVoter;
@@ -28,6 +29,30 @@ class CampController extends AbstractController
 
         $data = $demographicCampDataProvider->getData(
             $widgetRequestData->getGroup(),
+            $dateRangeRequestData->getFrom()->format('Y-m-d'),
+            $dateRangeRequestData->getTo()->format('Y-m-d'),
+            $widgetRequestData->getGroupTypes(),
+            $widgetRequestData->getPeopleTypes()
+        );
+
+        return $this->json($data);
+    }
+
+    /**
+     * @param DateRangeRequestData $dateRangeRequestData
+     * @param WidgetOfDepartmentRequestData $widgetRequestData
+     * @param DemographicCampDataProvider $demographicCampDataProvider
+     * @return JsonResponse
+     */
+    public function getDemographicCampDataOfDepartment(
+        DateRangeRequestData $dateRangeRequestData,
+        WidgetOfDepartmentRequestData $widgetRequestData,
+        DemographicCampDataProvider $demographicCampDataProvider
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $widgetRequestData->getGroup());
+
+        $data = $demographicCampDataProvider->getData(
+            $widgetRequestData->getDepartment(),
             $dateRangeRequestData->getFrom()->format('Y-m-d'),
             $dateRangeRequestData->getTo()->format('Y-m-d'),
             $widgetRequestData->getGroupTypes(),

--- a/src/Controller/Api/Apps/Widgets/FilterController.php
+++ b/src/Controller/Api/Apps/Widgets/FilterController.php
@@ -3,6 +3,8 @@
 namespace App\Controller\Api\Apps\Widgets;
 
 use App\Entity\Midata\Group;
+use App\Exception\ApiException;
+use App\Service\Apps\Overview\OverviewSharedService;
 use App\Service\DataProvider\FilterDataProvider;
 use App\Service\Security\PermissionVoter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
@@ -28,6 +30,34 @@ class FilterController extends AbstractController
         $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $group);
 
         $data = $filterDataProvider->getData($group, $request->getLocale());
+
+        return $this->json($data);
+    }
+
+    /**
+     * @param Request $request
+     * @param Group $group
+     * @param Group $department
+     * @param FilterDataProvider $filterDataProvider
+     * @return JsonResponse
+     *
+     * @ParamConverter("group", options={"mapping": {"groupId": "id"}})
+     * @ParamConverter("department", options={"mapping": {"departmentId": "id"}})
+     */
+    public function getFilterDataOfDepartment(
+        Request $request,
+        Group $group,
+        Group $department,
+        FilterDataProvider $filterDataProvider,
+        OverviewSharedService $overviewSharedService
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $group);
+
+        if (!$overviewSharedService->validateOverviewAccess($group, $department)) {
+            throw new ApiException(400, "Department has to be shared and a child of the parent group");
+        }
+
+        $data = $filterDataProvider->getData($department, $request->getLocale());
 
         return $this->json($data);
     }

--- a/src/Controller/Api/Apps/Widgets/GeoLocationController.php
+++ b/src/Controller/Api/Apps/Widgets/GeoLocationController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Api\Apps\Widgets;
 
 use App\DTO\Model\FilterRequestData\DateRequestData;
+use App\DTO\Model\FilterRequestData\WidgetOfDepartmentRequestData;
 use App\DTO\Model\FilterRequestData\WidgetRequestData;
 use App\Service\DataProvider\GeoLocationDateDataProvider;
 use App\Service\Security\PermissionVoter;
@@ -11,6 +12,13 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class GeoLocationController extends AbstractController
 {
+    /**
+     * @param GeoLocationDateDataProvider $dataProvider
+     * @param DateRequestData $dateRequestData
+     * @param WidgetRequestData $widgetRequestData
+     * @return JsonResponse
+     * @throws \Doctrine\DBAL\Exception
+     */
     public function getGeoLocations(
         GeoLocationDateDataProvider $dataProvider,
         DateRequestData $dateRequestData,
@@ -23,6 +31,34 @@ class GeoLocationController extends AbstractController
         if ($dateRequestData->getDate()) {
             $data = $dataProvider->getData(
                 $widgetRequestData->getGroup(),
+                $dateRequestData->getDate()->format('Y-m-d'),
+                $widgetRequestData->getGroupTypes(),
+                $widgetRequestData->getPeopleTypes()
+            );
+        }
+
+        return $this->json($data);
+    }
+
+    /**
+     * @param GeoLocationDateDataProvider $dataProvider
+     * @param DateRequestData $dateRequestData
+     * @param WidgetOfDepartmentRequestData $widgetRequestData
+     * @return JsonResponse
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function getGeoLocationsOfDepartment(
+        GeoLocationDateDataProvider $dataProvider,
+        DateRequestData $dateRequestData,
+        WidgetOfDepartmentRequestData $widgetRequestData
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $widgetRequestData->getGroup());
+
+        $data = [];
+
+        if ($dateRequestData->getDate()) {
+            $data = $dataProvider->getData(
+                $widgetRequestData->getDepartment(),
                 $dateRequestData->getDate()->format('Y-m-d'),
                 $widgetRequestData->getGroupTypes(),
                 $widgetRequestData->getPeopleTypes()

--- a/src/Controller/Api/Apps/Widgets/LeaderOverviewController.php
+++ b/src/Controller/Api/Apps/Widgets/LeaderOverviewController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Api\Apps\Widgets;
 
 use App\DTO\Model\FilterRequestData\DateRequestData;
+use App\DTO\Model\FilterRequestData\WidgetOfDepartmentRequestData;
 use App\DTO\Model\FilterRequestData\WidgetRequestData;
 use App\Service\DataProvider\LeaderOverviewDatePointDataProvider;
 use App\Service\Security\PermissionVoter;
@@ -26,6 +27,30 @@ class LeaderOverviewController extends AbstractController
 
         $data = $dataProvider->getData(
             $widgetRequestData->getGroup(),
+            $dateRequestData->getDate()->format('Y-m-d'),
+            $widgetRequestData->getGroupTypes(),
+            $widgetRequestData->getPeopleTypes()
+        );
+
+        return $this->json($data);
+    }
+
+    /**
+     * @param DateRequestData $dateRequestData
+     * @param WidgetOfDepartmentRequestData $widgetRequestData
+     * @param LeaderOverviewDatePointDataProvider $dataProvider
+     * @return JsonResponse
+     *
+     */
+    public function getLeaderOverviewDataOfDepartment(
+        DateRequestData $dateRequestData,
+        WidgetOfDepartmentRequestData $widgetRequestData,
+        LeaderOverviewDatePointDataProvider $dataProvider
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $widgetRequestData->getGroup());
+
+        $data = $dataProvider->getData(
+            $widgetRequestData->getDepartment(),
             $dateRequestData->getDate()->format('Y-m-d'),
             $widgetRequestData->getGroupTypes(),
             $widgetRequestData->getPeopleTypes()

--- a/src/Controller/Api/Apps/Widgets/MembersBirthyearController.php
+++ b/src/Controller/Api/Apps/Widgets/MembersBirthyearController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Api\Apps\Widgets;
 
 use App\DTO\Model\FilterRequestData\DateRequestData;
+use App\DTO\Model\FilterRequestData\WidgetOfDepartmentRequestData;
 use App\DTO\Model\FilterRequestData\WidgetRequestData;
 use App\Service\DataProvider\MembersBirthyearDateDataProvider;
 use App\Service\Security\PermissionVoter;
@@ -28,6 +29,28 @@ class MembersBirthyearController extends AbstractController
 
         $data = $membersBirthyearDateDataProvider->getData(
             $widgetRequestData->getGroup(),
+            $dateRequestData->getDate()->format('Y-m-d'),
+            $widgetRequestData->getGroupTypes(),
+            $widgetRequestData->getPeopleTypes()
+        );
+        return $this->json($data);
+    }
+
+    /**
+     * @param DateRequestData $dateRequestData
+     * @param WidgetOfDepartmentRequestData $widgetRequestData
+     * @param MembersBirthyearDateDataProvider $membersBirthyearDateDataProvider
+     * @return JsonResponse
+     */
+    public function getMembersBirthyearDataOfDepartment(
+        DateRequestData $dateRequestData,
+        WidgetOfDepartmentRequestData $widgetRequestData,
+        MembersBirthyearDateDataProvider $membersBirthyearDateDataProvider
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $widgetRequestData->getGroup());
+
+        $data = $membersBirthyearDateDataProvider->getData(
+            $widgetRequestData->getDepartment(),
             $dateRequestData->getDate()->format('Y-m-d'),
             $widgetRequestData->getGroupTypes(),
             $widgetRequestData->getPeopleTypes()

--- a/src/Controller/Api/Apps/Widgets/MembersEnteredLeftController.php
+++ b/src/Controller/Api/Apps/Widgets/MembersEnteredLeftController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Api\Apps\Widgets;
 
 use App\DTO\Model\FilterRequestData\DateRangeRequestData;
+use App\DTO\Model\FilterRequestData\WidgetOfDepartmentRequestData;
 use App\DTO\Model\FilterRequestData\WidgetRequestData;
 use App\Service\DataProvider\MembersEnteredLeftDateRangeDataProvider;
 use App\Service\Security\PermissionVoter;
@@ -28,6 +29,30 @@ class MembersEnteredLeftController extends AbstractController
 
         $data = $membersEnteredLeftDateRangeDataProvider->getData(
             $widgetRequestData->getGroup(),
+            $dateRangeRequestData->getFrom()->format('Y-m-d'),
+            $dateRangeRequestData->getTo()->format('Y-m-d'),
+            $widgetRequestData->getGroupTypes(),
+            $widgetRequestData->getPeopleTypes()
+        );
+
+        return $this->json($data);
+    }
+
+    /**
+     * @param DateRangeRequestData $dateRangeRequestData
+     * @param WidgetOfDepartmentRequestData $widgetRequestData
+     * @param MembersEnteredLeftDateRangeDataProvider $membersEnteredLeftDateRangeDataProvider
+     * @return JsonResponse
+     */
+    public function getEnteredLeftMembersDataOfDepartment(
+        DateRangeRequestData $dateRangeRequestData,
+        WidgetOfDepartmentRequestData $widgetRequestData,
+        MembersEnteredLeftDateRangeDataProvider $membersEnteredLeftDateRangeDataProvider
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $widgetRequestData->getGroup());
+
+        $data = $membersEnteredLeftDateRangeDataProvider->getData(
+            $widgetRequestData->getDepartment(),
             $dateRangeRequestData->getFrom()->format('Y-m-d'),
             $dateRangeRequestData->getTo()->format('Y-m-d'),
             $widgetRequestData->getGroupTypes(),

--- a/src/Controller/Api/Apps/Widgets/MembersGenderController.php
+++ b/src/Controller/Api/Apps/Widgets/MembersGenderController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Api\Apps\Widgets;
 
 use App\DTO\Model\FilterRequestData\DateAndDateRangeRequestData;
+use App\DTO\Model\FilterRequestData\WidgetOfDepartmentRequestData;
 use App\DTO\Model\FilterRequestData\WidgetRequestData;
 use App\Service\DataProvider\MembersGenderDateDataProvider;
 use App\Service\DataProvider\MembersGenderDateRangeDataProvider;
@@ -43,6 +44,45 @@ class MembersGenderController extends AbstractController
         if ($dateAndDateRangeRequestData->getFrom() && $dateAndDateRangeRequestData->getTo()) {
             $data = $membersGenderDateRangeDataProvider->getData(
                 $widgetRequestData->getGroup(),
+                $dateAndDateRangeRequestData->getFrom()->format('Y-m-d'),
+                $dateAndDateRangeRequestData->getTo()->format('Y-m-d'),
+                $widgetRequestData->getGroupTypes(),
+                $widgetRequestData->getPeopleTypes()
+            );
+        }
+
+        return $this->json($data);
+    }
+
+    /**
+     * @param DateAndDateRangeRequestData $dateAndDateRangeRequestData
+     * @param WidgetOfDepartmentRequestData $widgetRequestData
+     * @param MembersGenderDateDataProvider $membersGenderDateDataProvider
+     * @param MembersGenderDateRangeDataProvider $membersGenderDateRangeDataProvider
+     * @return Response
+     */
+    public function getDemographicGroupDataOfDepartment(
+        DateAndDateRangeRequestData $dateAndDateRangeRequestData,
+        WidgetOfDepartmentRequestData $widgetRequestData,
+        MembersGenderDateDataProvider $membersGenderDateDataProvider,
+        MembersGenderDateRangeDataProvider $membersGenderDateRangeDataProvider
+    ): Response {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $widgetRequestData->getGroup());
+
+        $data = [];
+
+        if ($dateAndDateRangeRequestData->getDate()) {
+            $data = $membersGenderDateDataProvider->getData(
+                $widgetRequestData->getDepartment(),
+                $dateAndDateRangeRequestData->getDate()->format('Y-m-d'),
+                $widgetRequestData->getPeopleTypes(),
+                $widgetRequestData->getGroupTypes()
+            );
+        }
+
+        if ($dateAndDateRangeRequestData->getFrom() && $dateAndDateRangeRequestData->getTo()) {
+            $data = $membersGenderDateRangeDataProvider->getData(
+                $widgetRequestData->getDepartment(),
                 $dateAndDateRangeRequestData->getFrom()->format('Y-m-d'),
                 $dateAndDateRangeRequestData->getTo()->format('Y-m-d'),
                 $widgetRequestData->getGroupTypes(),

--- a/src/Controller/Api/Apps/Widgets/MembersGroupController.php
+++ b/src/Controller/Api/Apps/Widgets/MembersGroupController.php
@@ -40,7 +40,7 @@ class MembersGroupController extends AbstractController
             $data = $membersGroupDateDataProvider->getData(
                 $group,
                 $date->format('Y-m-d'),
-                $membersGroupPreviewService->getGroupTypes($group),
+                $membersGroupPreviewService->getGroupTypes($group->getId()),
                 ['members', 'leaders']
             );
         }

--- a/src/Controller/Api/Apps/Widgets/MembersGroupController.php
+++ b/src/Controller/Api/Apps/Widgets/MembersGroupController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Api\Apps\Widgets;
 
 use App\DTO\Model\FilterRequestData\DateAndDateRangeRequestData;
+use App\DTO\Model\FilterRequestData\WidgetOfDepartmentRequestData;
 use App\DTO\Model\FilterRequestData\WidgetRequestData;
 use App\Entity\Midata\Group;
 use App\Service\Apps\Widgets\MembersGroupPreviewService;
@@ -78,6 +79,46 @@ class MembersGroupController extends AbstractController
         if ($dateAndDateRangeRequestData->getFrom() && $dateAndDateRangeRequestData->getTo()) {
             $data = $membersGroupDateRangeDataProvider->getData(
                 $widgetRequestData->getGroup(),
+                $dateAndDateRangeRequestData->getFrom()->format('Y-m-d'),
+                $dateAndDateRangeRequestData->getTo()->format('Y-m-d'),
+                $widgetRequestData->getGroupTypes(),
+                $widgetRequestData->getPeopleTypes()
+            );
+        }
+
+        return $this->json($data);
+    }
+
+    /**
+     * @param MembersGroupDateRangeDataProvider $membersGroupDateRangeDataProvider
+     * @param MembersGroupDateDataProvider $membersGroupDateDataProvider
+     * @param DateAndDateRangeRequestData $dateAndDateRangeRequestData
+     * @param WidgetOfDepartmentRequestData $widgetRequestData
+     * @return JsonResponse
+     * @throws \Exception
+     */
+    public function getGroupMembersDataOfDepartment(
+        MembersGroupDateRangeDataProvider $membersGroupDateRangeDataProvider,
+        MembersGroupDateDataProvider $membersGroupDateDataProvider,
+        DateAndDateRangeRequestData $dateAndDateRangeRequestData,
+        WidgetOfDepartmentRequestData $widgetRequestData
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $widgetRequestData->getGroup());
+
+        $data = [];
+
+        if ($dateAndDateRangeRequestData->getDate()) {
+            $data = $membersGroupDateDataProvider->getData(
+                $widgetRequestData->getDepartment(),
+                $dateAndDateRangeRequestData->getDate()->format('Y-m-d'),
+                $widgetRequestData->getGroupTypes(),
+                $widgetRequestData->getPeopleTypes()
+            );
+        }
+
+        if ($dateAndDateRangeRequestData->getFrom() && $dateAndDateRangeRequestData->getTo()) {
+            $data = $membersGroupDateRangeDataProvider->getData(
+                $widgetRequestData->getDepartment(),
                 $dateAndDateRangeRequestData->getFrom()->format('Y-m-d'),
                 $dateAndDateRangeRequestData->getTo()->format('Y-m-d'),
                 $widgetRequestData->getGroupTypes(),

--- a/src/Controller/Api/Apps/Widgets/RoleOverviewController.php
+++ b/src/Controller/Api/Apps/Widgets/RoleOverviewController.php
@@ -3,22 +3,56 @@
 namespace App\Controller\Api\Apps\Widgets;
 
 use App\DTO\Model\FilterRequestData\DateAndDateRangeRequestData;
+use App\DTO\Model\FilterRequestData\WidgetOfDepartmentRequestData;
 use App\DTO\Model\FilterRequestData\WidgetRequestData;
 use App\Service\DataProvider\MembersGroupDateDataProvider;
 use App\Service\DataProvider\MembersGroupDateRangeDataProvider;
 use App\Service\DataProvider\RoleOverviewDateRangeDataProvider;
 use App\Service\Security\PermissionVoter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 class RoleOverviewController extends AbstractController
 {
+    /**
+     * @param RoleOverviewDateRangeDataProvider $roleOverviewDateRangeDataProvider
+     * @param DateAndDateRangeRequestData $dateAndDateRangeRequestData
+     * @param WidgetRequestData $widgetRequestData
+     * @return JsonResponse
+     */
     public function getRoleOverview(
         RoleOverviewDateRangeDataProvider $roleOverviewDateRangeDataProvider,
         DateAndDateRangeRequestData $dateAndDateRangeRequestData,
         WidgetRequestData $widgetRequestData
-    ) {
+    ): JsonResponse {
         $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $widgetRequestData->getGroup());
-        $result = $roleOverviewDateRangeDataProvider->getData($widgetRequestData->getGroup(), $dateAndDateRangeRequestData->getFrom()->format('Y-m-d'), $dateAndDateRangeRequestData->getTo()->format('Y-m-d'));
+        $result = $roleOverviewDateRangeDataProvider->getData(
+            $widgetRequestData->getGroup(),
+            $dateAndDateRangeRequestData->getFrom()->format('Y-m-d'),
+            $dateAndDateRangeRequestData->getTo()->format('Y-m-d'),
+        );
+
+        return $this->json($result);
+    }
+
+    /**
+     * @param RoleOverviewDateRangeDataProvider $roleOverviewDateRangeDataProvider
+     * @param DateAndDateRangeRequestData $dateAndDateRangeRequestData
+     * @param WidgetOfDepartmentRequestData $widgetRequestData
+     * @return JsonResponse
+     */
+    public function getRoleOverviewOfDepartment(
+        RoleOverviewDateRangeDataProvider $roleOverviewDateRangeDataProvider,
+        DateAndDateRangeRequestData $dateAndDateRangeRequestData,
+        WidgetOfDepartmentRequestData $widgetRequestData
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted(PermissionVoter::VIEWER, $widgetRequestData->getGroup());
+        $result = $roleOverviewDateRangeDataProvider->getData(
+            $widgetRequestData->getDepartment(),
+            $dateAndDateRangeRequestData->getFrom()->format('Y-m-d'),
+            $dateAndDateRangeRequestData->getTo()->format('Y-m-d'),
+        );
+
         return $this->json($result);
     }
 }

--- a/src/DTO/Model/Apps/Overview/OverviewDepartmentDTO.php
+++ b/src/DTO/Model/Apps/Overview/OverviewDepartmentDTO.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\DTO\Model\Apps\Overview;
+
+use App\DTO\Model\Charts\PieChartDataDTO;
+
+class OverviewDepartmentDTO
+{
+    /**
+     * @var int
+     */
+    private int $id;
+
+    /**
+     * @var string
+     */
+    private string $name;
+
+    /**
+     * @var PieChartDataDTO[] $groupTypes;
+     */
+    private array $groupTypes;
+
+    /**
+     * @param int $id
+     * @param string $name
+     * @param PieChartDataDTO[] $groupTypes
+     */
+    public function __construct(int $id, string $name, array $groupTypes)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->groupTypes = $groupTypes;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return void
+     */
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return void
+     */
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return PieChartDataDTO[]
+     */
+    public function getGroupTypes(): array
+    {
+        return $this->groupTypes;
+    }
+
+    /**
+     * @param array $groupTypes
+     * @return void
+     */
+    public function setGroupTypes(array $groupTypes): void
+    {
+        $this->groupTypes = $groupTypes;
+    }
+}

--- a/src/DTO/Model/Apps/Overview/OverviewDepartmentsPreviewDTO.php
+++ b/src/DTO/Model/Apps/Overview/OverviewDepartmentsPreviewDTO.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\DTO\Model\Apps\Overview;
+
+use App\DTO\Model\Charts\PieChartDataDTO;
+
+class OverviewDepartmentsPreviewDTO
+{
+    /**
+     * @var int $departments
+     */
+    private int $departments;
+
+    /**
+     * @var PieChartDataDTO[] $groupTypes;
+     */
+    private array $groupTypes;
+
+    /**
+     * @param int $departments
+     * @param PieChartDataDTO[] $groupTypes
+     */
+    public function __construct(int $departments = 0, array $groupTypes = [])
+    {
+        $this->departments = $departments;
+        $this->groupTypes = $groupTypes;
+    }
+
+
+    /**
+     * @return int
+     */
+    public function getDepartments(): int
+    {
+        return $this->departments;
+    }
+
+    /**
+     * @param int $departments
+     * @return void
+     */
+    public function setDepartments(int $departments): void
+    {
+        $this->departments = $departments;
+    }
+
+    /**
+     * @return PieChartDataDTO[]
+     */
+    public function getGroupTypes(): array
+    {
+        return $this->groupTypes;
+    }
+
+    /**
+     * @param array $groupTypes
+     * @return void
+     */
+    public function setGroupTypes(array $groupTypes): void
+    {
+        $this->groupTypes = $groupTypes;
+    }
+}

--- a/src/DTO/Model/Apps/Overview/OverviewRegionDTO.php
+++ b/src/DTO/Model/Apps/Overview/OverviewRegionDTO.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\DTO\Model\Apps\Overview;
+
+class OverviewRegionDTO
+{
+    /**
+     * @var string|null
+     */
+    private ?string $name;
+
+    /**
+     * @var OverviewDepartmentDTO[] $children
+     */
+    private array $children;
+
+    /**
+     * @param string|null $name
+     * @param OverviewDepartmentDTO[] $children
+     */
+    public function __construct(string $name = null, array $children = [])
+    {
+        $this->name = $name;
+        $this->children = $children;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string|null $name
+     * @return void
+     */
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return OverviewDepartmentDTO[]
+     */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    /**
+     * @param array $children
+     * @return void
+     */
+    public function setChildren(array $children): void
+    {
+        $this->children = $children;
+    }
+}

--- a/src/DTO/Model/Apps/Overview/OverviewSharingDTO.php
+++ b/src/DTO/Model/Apps/Overview/OverviewSharingDTO.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\DTO\Model\Apps\Overview;
+
+class OverviewSharingDTO
+{
+    /** @var bool $sharing */
+    private bool $sharing;
+
+    /**
+     * @param bool $sharing
+     */
+    public function __construct(bool $sharing)
+    {
+        $this->sharing = $sharing;
+    }
+
+
+    public function isSharing(): bool
+    {
+        return $this->sharing;
+    }
+
+    public function setSharing(bool $sharing): void
+    {
+        $this->sharing = $sharing;
+    }
+}

--- a/src/DTO/Model/FilterRequestData/WidgetOfDepartmentRequestData.php
+++ b/src/DTO/Model/FilterRequestData/WidgetOfDepartmentRequestData.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\DTO\Model\FilterRequestData;
+
+use App\Entity\Midata\Group;
+
+class WidgetOfDepartmentRequestData extends WidgetRequestData
+{
+    /**
+     * @var Group
+     */
+    private Group $department;
+
+    public function getDepartment(): Group
+    {
+        return $this->department;
+    }
+
+    public function setDepartment(Group $department): void
+    {
+        $this->department = $department;
+    }
+}

--- a/src/Entity/Midata/GroupType.php
+++ b/src/Entity/Midata/GroupType.php
@@ -22,8 +22,9 @@ class GroupType
     public const WOELFE = 'Group::Woelfe';
     public const PFADI = 'Group::Pfadi';
     public const PIO = 'Group::Pio';
+    public const ABTEILUNGS_ROVER = 'Group::AbteilungsRover';
     public const ROVER = 'Group::RegionaleRover';
-    public const PTA = 13;
+    public const PTA = 'Group::Pta';
 
     /**
      * @ORM\Id()

--- a/src/Entity/Overview/OverviewShared.php
+++ b/src/Entity/Overview/OverviewShared.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Entity\Overview;
+
+use App\Repository\Overview\OverviewSharedRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass=OverviewSharedRepository::class)
+ * @ORM\Table(name="hc_overview_shared")
+ */
+class OverviewShared
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private int $id;
+
+    /**
+     * @ORM\Column(name="group_id", type="integer")
+     */
+    private int $groupId;
+
+    /**
+     * @ORM\Column(type="datetime_immutable")
+     */
+    private \DateTimeImmutable $createdAt;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getGroupId(): int
+    {
+        return $this->groupId;
+    }
+
+    public function setGroupId(int $groupId): void
+    {
+        $this->groupId = $groupId;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/src/EventListener/WidgetControllerListener.php
+++ b/src/EventListener/WidgetControllerListener.php
@@ -8,10 +8,12 @@ use App\DTO\Model\FilterRequestData\DateRangeRequestData;
 use App\DTO\Model\FilterRequestData\DateRequestData;
 use App\DTO\Model\FilterRequestData\FilterRequestData;
 use App\DTO\Model\FilterRequestData\OptionalDateRequestData;
+use App\DTO\Model\FilterRequestData\WidgetOfDepartmentRequestData;
 use App\DTO\Model\FilterRequestData\WidgetRequestData;
 use App\Entity\Midata\Group;
 use App\Exception\ApiException;
 use App\Repository\Midata\GroupRepository;
+use App\Service\Apps\Overview\OverviewSharedService;
 use App\Service\DataProvider\WidgetDataProvider;
 use DateTime;
 use ReflectionClass;
@@ -29,32 +31,40 @@ class WidgetControllerListener
     /**
      * @var GroupRepository
      */
-    private $groupRepository;
+    private GroupRepository $groupRepository;
 
     /**
      * @var TranslatorInterface
      */
-    private $translator;
+    private TranslatorInterface $translator;
 
     /**
      * @var ValidatorInterface
      */
-    private $validator;
+    private ValidatorInterface $validator;
+
+    /**
+     * @var OverviewSharedService
+     */
+    private OverviewSharedService $overviewSharedService;
 
     /**
      * WidgetControllerListener constructor.
      * @param GroupRepository $groupRepository
      * @param TranslatorInterface $translator
      * @param ValidatorInterface $validator
+     * @param OverviewSharedService $overviewSharedService
      */
     public function __construct(
         GroupRepository $groupRepository,
         TranslatorInterface $translator,
-        ValidatorInterface $validator
+        ValidatorInterface $validator,
+        OverviewSharedService $overviewSharedService
     ) {
         $this->groupRepository = $groupRepository;
         $this->translator = $translator;
         $this->validator = $validator;
+        $this->overviewSharedService = $overviewSharedService;
     }
 
 
@@ -94,18 +104,7 @@ class WidgetControllerListener
      */
     private function validateRequest(Request $request, ReflectionParameter $parameter)
     {
-        $groupId = $request->get('groupId');
-        $group = $this->groupRepository->findOneByIdAndType($groupId, [
-            'Group::Abteilung',
-            'Group::Region',
-            'Group::Kantonalverband',
-            'Group::Bund',
-        ]);
-        if (!$group) {
-            $entity = $this->translator->trans('api.entity.group');
-            $message = $this->translator->trans('api.error.notFound', ['entityName' => $entity]);
-            throw new ApiException(Response::HTTP_NOT_FOUND, $message);
-        }
+        $group = $this->extractGroup($request, 'groupId');
 
         switch ($parameter->getClass()->getName()) {
             case DateAndDateRangeRequestData::class:
@@ -118,6 +117,8 @@ class WidgetControllerListener
                 return $this->validateDateRangeRequest($group, $request);
             case WidgetRequestData::class:
                 return $this->validateWidgetRequest($group, $request);
+            case WidgetOfDepartmentRequestData::class:
+                return $this->validateWidgetOfDepartmentRequest($group, $request);
             case CensusRequestData::class:
                 return $this->validateCensusRequest($group, $request);
         }
@@ -219,6 +220,25 @@ class WidgetControllerListener
         return $data;
     }
 
+    private function validateWidgetOfDepartmentRequest(Group $group, Request $request): WidgetOfDepartmentRequestData
+    {
+        $department = $this->extractGroup($request, 'departmentId');
+
+        if (!$this->overviewSharedService->validateOverviewAccess($group, $department)) {
+            throw new ApiException(400, "Department has to be shared and a child of the parent group");
+        }
+
+        $widgetData = $this->validateWidgetRequest($group, $request);
+
+        $data = new WidgetOfDepartmentRequestData();
+        $data->setDepartment($department);
+        $data->setGroup($widgetData->getGroup());
+        $data->setGroupTypes($widgetData->getGroupTypes());
+        $data->setPeopleTypes($widgetData->getPeopleTypes());
+
+        return $data;
+    }
+
     private function validateCensusRequest(Group $group, Request $request): CensusRequestData
     {
         $m = $request->get('census-filter-males');
@@ -277,5 +297,26 @@ class WidgetControllerListener
             return;
         }
         throw new ApiException(Response::HTTP_UNPROCESSABLE_ENTITY, $message);
+    }
+
+    /**
+     * @param Request $request
+     * @return float|int|mixed|string
+     */
+    public function extractGroup(Request $request, string $key)
+    {
+        $groupId = $request->get($key);
+        $group = $this->groupRepository->findOneByIdAndType($groupId, [
+            'Group::Abteilung',
+            'Group::Region',
+            'Group::Kantonalverband',
+            'Group::Bund',
+        ]);
+        if (!$group) {
+            $entity = $this->translator->trans('api.entity.group');
+            $message = $this->translator->trans('api.error.notFound', ['entityName' => $entity]);
+            throw new ApiException(Response::HTTP_NOT_FOUND, $message);
+        }
+        return $group;
     }
 }

--- a/src/Migrations/Version20251113142918.php
+++ b/src/Migrations/Version20251113142918.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251113142918 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // create hc_overview_shared table
+        $this->addSql('CREATE SEQUENCE hc_overview_shared_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE hc_overview_shared (id INT NOT NULL, group_id INT NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('ALTER TABLE hc_overview_shared ADD CONSTRAINT FK_52135CE26C5A5391 FOREIGN KEY (group_id) REFERENCES midata_group (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE hc_overview_shared');
+        $this->addSql('DROP SEQUENCE hc_overview_shared_id_seq');
+    }
+}

--- a/src/Model/OverviewPreview.php
+++ b/src/Model/OverviewPreview.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Model;
+
+use App\Entity\Midata\Group;
+
+class OverviewPreview
+{
+    /**
+     * @var Group $group
+     */
+    private Group $group;
+    /**
+     * @var array<string, int> $groupTypes
+     */
+    private array $groupTypes;
+
+    /**
+     * @param Group $group
+     * @param array<string, int> $groupTypes
+     */
+    public function __construct(Group $group, array $groupTypes = [])
+    {
+        $this->group = $group;
+        $this->groupTypes = $groupTypes;
+    }
+
+    public function getGroup(): Group
+    {
+        return $this->group;
+    }
+
+    public function setGroup(Group $group): void
+    {
+        $this->group = $group;
+    }
+
+    public function getGroupTypes(): array
+    {
+        return $this->groupTypes;
+    }
+
+    public function setGroupTypes(array $groupTypes): void
+    {
+        $this->groupTypes = $groupTypes;
+    }
+}

--- a/src/Repository/Overview/OverviewSharedRepository.php
+++ b/src/Repository/Overview/OverviewSharedRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Repository\Overview;
+
+use App\Entity\Overview\OverviewShared;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method OverviewShared|null find($id, $lockMode = null, $lockVersion = null)
+ * @method OverviewShared|null findOneBy(array $criteria, array $orderBy = null)
+ * @method OverviewShared[]    findAll()
+ * @method OverviewShared[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class OverviewSharedRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, OverviewShared::class);
+    }
+
+    public function findByGroupId(int $groupId): ?OverviewShared
+    {
+        return $this->createQueryBuilder("o")
+            ->where('o.groupId =:groupId')
+            ->setParameter('groupId', $groupId)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/src/Repository/Overview/OverviewSharedRepository.php
+++ b/src/Repository/Overview/OverviewSharedRepository.php
@@ -27,4 +27,18 @@ class OverviewSharedRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    public function save(OverviewShared $overviewShared)
+    {
+        $em = $this->getEntityManager();
+        $em->persist($overviewShared);
+        $em->flush();
+    }
+
+    public function remove(OverviewShared $overviewShared)
+    {
+        $em = $this->getEntityManager();
+        $em->remove($overviewShared);
+        $em->flush();
+    }
 }

--- a/src/Service/Apps/Overview/OverviewSharedService.php
+++ b/src/Service/Apps/Overview/OverviewSharedService.php
@@ -2,16 +2,21 @@
 
 namespace App\Service\Apps\Overview;
 
+use App\DTO\Model\Apps\Overview\OverviewDepartmentDTO;
 use App\DTO\Model\Apps\Overview\OverviewDepartmentsPreviewDTO;
+use App\DTO\Model\Apps\Overview\OverviewRegionDTO;
 use App\DTO\Model\Charts\PieChartDataDTO;
 use App\Entity\Midata\Group;
 use App\Entity\Midata\GroupType;
 use App\Entity\Overview\OverviewShared;
+use App\Model\OverviewPreview;
 use App\Repository\Aggregated\AggregatedDemographicGroupRepository;
+use App\Repository\Midata\GroupRepository;
 use App\Repository\Overview\OverviewSharedRepository;
 use App\Repository\Statistics\StatisticGroupRepository;
 use App\Service\Apps\Widgets\MembersGroupPreviewService;
 use App\Service\DataProvider\WidgetDataProvider;
+use Doctrine\DBAL\Exception;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class OverviewSharedService
@@ -25,6 +30,11 @@ class OverviewSharedService
      * @var OverviewSharedRepository $sharedOverviewRepository
      */
     private OverviewSharedRepository $sharedOverviewRepository;
+
+    /**
+     * @var GroupRepository $groupRepository
+     */
+    private GroupRepository $groupRepository;
 
     /**
      * @var StatisticGroupRepository $statisticGroupRepository
@@ -44,12 +54,14 @@ class OverviewSharedService
     public function __construct(
         TranslatorInterface $translator,
         OverviewSharedRepository $sharedOverviewRepository,
+        GroupRepository $groupRepository,
         StatisticGroupRepository $statisticGroupRepository,
         MembersGroupPreviewService $membersGroupPreviewService,
         AggregatedDemographicGroupRepository $demographicGroupRepository
     ) {
         $this->translator = $translator;
         $this->sharedOverviewRepository = $sharedOverviewRepository;
+        $this->groupRepository = $groupRepository;
         $this->statisticGroupRepository = $statisticGroupRepository;
         $this->membersGroupPreviewService = $membersGroupPreviewService;
         $this->demographicGroupRepository = $demographicGroupRepository;
@@ -124,17 +136,13 @@ class OverviewSharedService
      */
     public function getDepartmentsPreview(Group $group): OverviewDepartmentsPreviewDTO
     {
-        $date = $this->membersGroupPreviewService->getNewestDate();
+        $date = $this->getLatestDemographicGroupAggregationDate();
         // if there is no aggregated data we have to return an empty preview
         if (is_null($date)) {
             return new OverviewDepartmentsPreviewDTO();
         }
-        $date = $date->format("Y-m-d");
 
-        $departmentIds = $this->statisticGroupRepository->findAllRelevantChildGroups($group->getId(), [GroupType::DEPARTMENT]);
-
-        // filter out the departments that haven't shared the overview
-        $departmentIds = array_filter($departmentIds, fn($id) => $this->isShared($id));
+        $departmentIds = $this->getSharedDepartments($group);
         $departmentCount = count($departmentIds);
 
         // return an empty preview because no department was shared
@@ -166,15 +174,136 @@ class OverviewSharedService
             $peopleCountPerGroupType[GroupType::DEPARTMENT] += $leaderCount ?? 0;
         }
 
-        // map the group types to pie chart DTOs
-        $pieCharts = [];
-
+        // ignore group types that have no people in it
         foreach ($peopleCountPerGroupType as $groupType => $count) {
-            // ignore group types that have no people in it
             if ($count === 0) {
+                unset($peopleCountPerGroupType[$groupType]);
+            }
+        }
+
+        // map the group types to pie chart DTOs
+        $pieCharts = $this->mapToPieChartDTOs($peopleCountPerGroupType);
+
+        return new OverviewDepartmentsPreviewDTO($departmentCount, $pieCharts);
+    }
+
+    /**
+     * @param Group $group
+     * @return OverviewRegionDTO[]
+     * @throws Exception
+     */
+    public function getDepartments(Group $group): array
+    {
+        $date = $this->getLatestDemographicGroupAggregationDate();
+        // if there is no aggregated data we have to return an empty preview
+        if (is_null($date)) {
+            return [];
+        }
+
+        $departmentIds = $this->getSharedDepartments($group);
+
+        // query the number of people per group type across all departments
+        $overviewPreviews = [];
+
+        foreach ($departmentIds as $departmentId) {
+            /** @var Group|null $department */
+            $department = $this->groupRepository->findOneBy(['id' => $departmentId]);
+
+            if (is_null($department)) {
+                throw new \Exception("the group ($departmentId) cannot be null");
+            }
+
+            $groupTypes = $this->membersGroupPreviewService->getGroupTypes($departmentId);
+            $groupTypesCount = [];
+
+            foreach ($groupTypes as $type) {
+                $count = $this->demographicGroupRepository->findMembersCountForDateAndGroupType($date, $type, $departmentId);
+                $groupTypesCount[$type] = $count ?? 0;
+            }
+
+            $leaderCount = $this->demographicGroupRepository->findTotalLeadersCountForDate($date, $departmentId, $groupTypes);
+            $groupTypesCount[GroupType::DEPARTMENT] = $leaderCount ?? 0;
+
+            $overviewPreviews[] = new OverviewPreview($department, $groupTypesCount);
+        }
+
+        if ($group->getGroupType()->getGroupType() === GroupType::REGION) {
+            // name can be empty because all departments are from the same region
+            return [$this->mapToRegionOverviewDTO(null, $overviewPreviews)];
+        }
+
+        // group the overviews by their region if there is one
+        /** @var array<int, OverviewPreview> $regionIdToOverviewPreviews */
+        $regionIdToOverviewPreviews = [];
+        /** @var OverviewPreview[] $regionlessOverviewPreviews */
+        $regionlessOverviewPreviews = [];
+
+        foreach ($overviewPreviews as $preview) {
+            $parentGroup = $preview->getGroup()->getParentGroup();
+            if (is_null($parentGroup) || $parentGroup->getGroupType()->getGroupType() !== GroupType::REGION) {
+                $regionlessOverviewPreviews[] = $preview;
                 continue;
             }
 
+            if (!array_key_exists($parentGroup->getId(), $regionIdToOverviewPreviews)) {
+                $regionIdToOverviewPreviews[$parentGroup->getId()] = [];
+            }
+
+            $regionIdToOverviewPreviews[$parentGroup->getId()][] = $preview;
+        }
+
+        $dtos = [];
+
+        foreach ($regionIdToOverviewPreviews as $previews) {
+            $regionName = $previews[0]->getGroup()->getParentGroup()->getName();
+
+            $dtos[] = $this->mapToRegionOverviewDTO($regionName, $previews);
+        }
+
+        foreach ($regionlessOverviewPreviews as $preview) {
+            $dtos[] = $this->mapToRegionOverviewDTO(null, [$preview]);
+        }
+
+        usort($dtos, fn($a, $b) => $this->sortOverviewRegionByName($a, $b));
+
+        return $dtos;
+    }
+
+    /**
+     * @param Group $group
+     * @return array
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function getSharedDepartments(Group $group): array
+    {
+        $departmentIds = $this->statisticGroupRepository->findAllRelevantChildGroups($group->getId(), [GroupType::DEPARTMENT]);
+
+        // filter out the departments that haven't shared the overview
+        return array_filter($departmentIds, fn($id) => $this->isShared($id));
+    }
+
+    /**
+     * @return string|null
+     */
+    private function getLatestDemographicGroupAggregationDate(): ?string
+    {
+        $date = $this->membersGroupPreviewService->getNewestDate();
+        if (is_null($date)) {
+            return null;
+        }
+
+        return $date->format("Y-m-d");
+    }
+
+    /**
+     * @param array<string, int> $groupTypes
+     * @return PieChartDataDTO[]
+     */
+    private function mapToPieChartDTOs(array $groupTypes): array
+    {
+        $pieCharts = [];
+
+        foreach ($groupTypes as $groupType => $count) {
             $groupTypeTranslation = $this->translator->trans("group.labels.members.$groupType");
 
             $pieChart = new PieChartDataDTO();
@@ -185,6 +314,67 @@ class OverviewSharedService
             $pieCharts[] = $pieChart;
         }
 
-        return new OverviewDepartmentsPreviewDTO($departmentCount, $pieCharts);
+        return $pieCharts;
+    }
+
+    /**
+     * @param string|null $regionName
+     * @param OverviewPreview[] $overviewPreviews
+     * @return OverviewRegionDTO
+     */
+    public function mapToRegionOverviewDTO(?string $regionName, array $overviewPreviews): OverviewRegionDTO
+    {
+        $overviewDepartments = [];
+
+        foreach ($overviewPreviews as $preview) {
+            $pieCharts = $this->mapToPieChartDTOs($preview->getGroupTypes());
+
+            $group = $preview->getGroup();
+
+            $overviewDepartments[] = new OverviewDepartmentDTO(
+                $group->getId(),
+                $group->getName(),
+                $pieCharts
+            );
+        }
+
+        // sort alphabetically
+        usort($overviewDepartments, fn($a, $b) => $this->sortOverviewDepartmentByName($a, $b));
+
+        return new OverviewRegionDTO($regionName, $overviewDepartments);
+    }
+
+    /**
+     * @param OverviewDepartmentDTO $a
+     * @param OverviewDepartmentDTO $b
+     * @return int
+     */
+    private function sortOverviewDepartmentByName(OverviewDepartmentDTO $a, OverviewDepartmentDTO $b): int
+    {
+        return strcmp($a->getName(), $b->getName());
+    }
+
+
+    /**
+     * @param OverviewRegionDTO $a
+     * @param OverviewRegionDTO $b
+     * @return int
+     */
+    private function sortOverviewRegionByName(OverviewRegionDTO $a, OverviewRegionDTO $b): int
+    {
+        // compare children names if the region name is null
+        if (is_null($a->getName()) && is_null($b->getName())) {
+            return strcmp($a->getChildren()[0]->getName(), $b->getChildren()[0]->getName());
+        }
+
+        if (is_null($a->getName())) {
+            return 1;
+        }
+
+        if (is_null($b->getName())) {
+            return -1;
+        }
+
+        return strcmp($a->getName(), $b->getName());
     }
 }

--- a/src/Service/Apps/Overview/OverviewSharedService.php
+++ b/src/Service/Apps/Overview/OverviewSharedService.php
@@ -86,7 +86,7 @@ class OverviewSharedService
         if ($department->getGroupType()->getGroupType() !== GroupType::DEPARTMENT) {
             return false;
         }
-        
+
         $departmentIds = $this->getSharedDepartments($parent);
 
         return in_array($department->getId(), $departmentIds);

--- a/src/Service/Apps/Overview/OverviewSharedService.php
+++ b/src/Service/Apps/Overview/OverviewSharedService.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Apps\Overview;
 
+use App\Entity\Overview\OverviewShared;
 use App\Repository\Overview\OverviewSharedRepository;
 
 class OverviewSharedService
@@ -22,5 +23,28 @@ class OverviewSharedService
         $entry = $this->sharedOverviewRepository->findByGroupId($groupId);
 
         return !is_null($entry);
+    }
+
+    /**
+     * @param int $groupId
+     * @param bool $share whether the group should share the overview
+     * @return void
+     */
+    public function shareOverview(int $groupId, bool $share)
+    {
+        $entry = $this->sharedOverviewRepository->findByGroupId($groupId);
+
+        if (!$share && !is_null($entry)) {
+            $this->sharedOverviewRepository->remove($entry);
+            return;
+        }
+
+        if ($share && is_null($entry)) {
+            $entry = new OverviewShared();
+            $entry->setGroupId($groupId);
+            $entry->setCreatedAt(new \DateTimeImmutable('now'));
+
+            $this->sharedOverviewRepository->save($entry);
+        }
     }
 }

--- a/src/Service/Apps/Overview/OverviewSharedService.php
+++ b/src/Service/Apps/Overview/OverviewSharedService.php
@@ -86,24 +86,10 @@ class OverviewSharedService
         if ($department->getGroupType()->getGroupType() !== GroupType::DEPARTMENT) {
             return false;
         }
+        
+        $departmentIds = $this->getSharedDepartments($parent);
 
-        // check if the department is shared
-        if (!$this->isShared($department->getId())) {
-            return false;
-        }
-
-        // check if the parent group is the canton of the department
-        if ($department->getCantonId() === $parent->getId()) {
-            return true;
-        }
-
-        // validate if the department is the direct child of the parent
-        $departmentParentGroup = $department->getParentGroup();
-        if (!is_null($departmentParentGroup) && $departmentParentGroup->getId() === $parent->getId()) {
-            return true;
-        }
-
-        return false;
+        return in_array($department->getId(), $departmentIds);
     }
 
     /**

--- a/src/Service/Apps/Overview/OverviewSharedService.php
+++ b/src/Service/Apps/Overview/OverviewSharedService.php
@@ -2,20 +2,57 @@
 
 namespace App\Service\Apps\Overview;
 
+use App\DTO\Model\Apps\Overview\OverviewDepartmentsPreviewDTO;
+use App\DTO\Model\Charts\PieChartDataDTO;
+use App\Entity\Midata\Group;
+use App\Entity\Midata\GroupType;
 use App\Entity\Overview\OverviewShared;
+use App\Repository\Aggregated\AggregatedDemographicGroupRepository;
 use App\Repository\Overview\OverviewSharedRepository;
+use App\Repository\Statistics\StatisticGroupRepository;
+use App\Service\Apps\Widgets\MembersGroupPreviewService;
+use App\Service\DataProvider\WidgetDataProvider;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class OverviewSharedService
 {
+    /**
+     * @var TranslatorInterface
+     */
+    protected TranslatorInterface $translator;
+
     /**
      * @var OverviewSharedRepository $sharedOverviewRepository
      */
     private OverviewSharedRepository $sharedOverviewRepository;
 
+    /**
+     * @var StatisticGroupRepository $statisticGroupRepository
+     */
+    private StatisticGroupRepository $statisticGroupRepository;
+
+    /**
+     * @var MembersGroupPreviewService $membersGroupPreviewService
+     */
+    private MembersGroupPreviewService $membersGroupPreviewService;
+
+    /**
+     * @var AggregatedDemographicGroupRepository $demographicGroupRepository
+     */
+    private AggregatedDemographicGroupRepository $demographicGroupRepository;
+
     public function __construct(
-        OverviewSharedRepository $sharedOverviewRepository
+        TranslatorInterface $translator,
+        OverviewSharedRepository $sharedOverviewRepository,
+        StatisticGroupRepository $statisticGroupRepository,
+        MembersGroupPreviewService $membersGroupPreviewService,
+        AggregatedDemographicGroupRepository $demographicGroupRepository
     ) {
+        $this->translator = $translator;
         $this->sharedOverviewRepository = $sharedOverviewRepository;
+        $this->statisticGroupRepository = $statisticGroupRepository;
+        $this->membersGroupPreviewService = $membersGroupPreviewService;
+        $this->demographicGroupRepository = $demographicGroupRepository;
     }
 
     public function isShared(int $groupId): bool
@@ -46,5 +83,76 @@ class OverviewSharedService
 
             $this->sharedOverviewRepository->save($entry);
         }
+    }
+
+    /**
+     * @param Group $group
+     * @return OverviewDepartmentsPreviewDTO
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function getDepartmentsPreview(Group $group): OverviewDepartmentsPreviewDTO
+    {
+        $date = $this->membersGroupPreviewService->getNewestDate();
+        // if there is no aggregated data we have to return an empty preview
+        if (is_null($date)) {
+            return new OverviewDepartmentsPreviewDTO();
+        }
+        $date = $date->format("Y-m-d");
+
+        $departmentIds = $this->statisticGroupRepository->findAllRelevantChildGroups($group->getId(), [GroupType::DEPARTMENT]);
+
+        // filter out the departments that haven't shared the overview
+        $departmentIds = array_filter($departmentIds, fn($id) => $this->isShared($id));
+        $departmentCount = count($departmentIds);
+
+        // return an empty preview because no department was shared
+        if ($departmentCount === 0) {
+            return new OverviewDepartmentsPreviewDTO();
+        }
+
+        $peopleCountPerGroupType = [
+            GroupType::BIBER => 0,
+            GroupType::WOELFE => 0,
+            GroupType::PFADI => 0,
+            GroupType::PIO => 0,
+            GroupType::ABTEILUNGS_ROVER => 0,
+            GroupType::PTA => 0,
+            // leaders
+            GroupType::DEPARTMENT => 0,
+        ];
+
+        // get the number of people by group types foreach department
+        foreach ($departmentIds as $departmentId) {
+            $groupTypes = $this->membersGroupPreviewService->getGroupTypes($departmentId);
+
+            foreach ($groupTypes as $type) {
+                $count = $this->demographicGroupRepository->findMembersCountForDateAndGroupType($date, $type, $departmentId);
+                $peopleCountPerGroupType[$type] += $count ?? 0;
+            }
+
+            $leaderCount = $this->demographicGroupRepository->findTotalLeadersCountForDate($date, $departmentId, $groupTypes);
+            $peopleCountPerGroupType[GroupType::DEPARTMENT] += $leaderCount ?? 0;
+        }
+
+        // map the group types to pie chart DTOs
+        $pieCharts = [];
+
+        foreach ($peopleCountPerGroupType as $groupType => $count) {
+            // ignore group types that have no people in it
+            if ($count === 0) {
+                continue;
+            }
+
+            $groupTypeTranslation = $this->translator->trans("group.labels.members.$groupType");
+
+            $pieChart = new PieChartDataDTO();
+            $pieChart->setValue($count);
+            $pieChart->setColor(WidgetDataProvider::GROUP_TYPE_COLORS[$groupType]);
+            $pieChart->setName($groupTypeTranslation);
+
+            $pieCharts[] = $pieChart;
+        }
+
+        return new OverviewDepartmentsPreviewDTO($departmentCount, $pieCharts);
     }
 }

--- a/src/Service/Apps/Overview/OverviewSharedService.php
+++ b/src/Service/Apps/Overview/OverviewSharedService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Service\Apps\Overview;
+
+use App\Repository\Overview\OverviewSharedRepository;
+
+class OverviewSharedService
+{
+    /**
+     * @var OverviewSharedRepository $sharedOverviewRepository
+     */
+    private OverviewSharedRepository $sharedOverviewRepository;
+
+    public function __construct(
+        OverviewSharedRepository $sharedOverviewRepository
+    ) {
+        $this->sharedOverviewRepository = $sharedOverviewRepository;
+    }
+
+    public function isShared(int $groupId): bool
+    {
+        $entry = $this->sharedOverviewRepository->findByGroupId($groupId);
+
+        return !is_null($entry);
+    }
+}

--- a/src/Service/Apps/Overview/OverviewSharedService.php
+++ b/src/Service/Apps/Overview/OverviewSharedService.php
@@ -62,6 +62,38 @@ class OverviewSharedService
         return !is_null($entry);
     }
 
+    public function validateOverviewAccess(Group $parent, Group $department): bool
+    {
+        // validate group type of the parent group
+        $parentGroupType = $parent->getGroupType()->getGroupType();
+        if ($parentGroupType !== GroupType::REGION && $parentGroupType !== GroupType::CANTON) {
+            return false;
+        }
+
+        // validate group type of the department
+        if ($department->getGroupType()->getGroupType() !== GroupType::DEPARTMENT) {
+            return false;
+        }
+
+        // check if the department is shared
+        if (!$this->isShared($department->getId())) {
+            return false;
+        }
+
+        // check if the parent group is the canton of the department
+        if ($department->getCantonId() === $parent->getId()) {
+            return true;
+        }
+
+        // validate if the department is the direct child of the parent
+        $departmentParentGroup = $department->getParentGroup();
+        if (!is_null($departmentParentGroup) && $departmentParentGroup->getId() === $parent->getId()) {
+            return true;
+        }
+
+        return false;
+    }
+
     /**
      * @param int $groupId
      * @param bool $share whether the group should share the overview

--- a/src/Service/Apps/Widgets/MembersGroupPreviewService.php
+++ b/src/Service/Apps/Widgets/MembersGroupPreviewService.php
@@ -32,9 +32,9 @@ class MembersGroupPreviewService
         return $aggregatedData[0]->getDataPointDate();
     }
 
-    public function getGroupTypes(Group $group): array
+    public function getGroupTypes(int $groupId): array
     {
-        $subGroups = $this->groupRepository->findAllRelevantSubGroupIdsByParentGroupId($group->getId());
+        $subGroups = $this->groupRepository->findAllRelevantSubGroupIdsByParentGroupId($groupId);
 
         return array_unique(array_map(function ($groupId): string {
             $g = $this->groupRepository->find($groupId);


### PR DESCRIPTION
Implemented endpoints to:
- get and set the sharing state as department
- get a preview of the shared departments as region/canton
- get shared departments as region/canton
- get the widget data of a department as region/canton 

I created all endpoints under `/overview` because we should split the widgets into `overview` and `census`.

Issue: https://github.com/digio-ch/pbs-healthcheck-core/issues/117